### PR TITLE
fix a bug in error reporting

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -250,7 +250,7 @@ function parse(strng::String)
         if pos+20<len
             return "$(strng[pos:pos+20])..."
         else 
-            return "strng[pos:len]"
+            return strng[pos:len]
         end 
     end
 


### PR DESCRIPTION
This fixes the following:

```
julia> JSON.parse("[a,b]")
Value expected at position 2: strng[pos:len]
```
