### PR TITLE
Bug fixes and performance improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ##Installation
 
 ```julia
-load("pkg")
+require("pkg")
 Pkg.init() #If not run once before
 Pkg.add("JSON")
 ```
@@ -11,7 +11,7 @@ Pkg.add("JSON")
 ##Usage
 
 ```julia
-load("JSON")
+require("JSON")
 JSON.parse(s)
 JSON.to_json(a)
 ```

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -29,11 +29,13 @@ end
 
 function print_to_json(io::IO, a::Vector)
     print(io, "[")
-    for x in a[1:end-1]
-        print_to_json(io, x)
-        print(io, ",")
+    if length(a) > 0
+        for x in a[1:end-1]
+            print_to_json(io, x)
+            print(io, ",")
+        end
+        print_to_json(io, a[end])
     end
-    print_to_json(io, a[end])
     print(io, "]")
 end
 
@@ -54,6 +56,9 @@ function print_to_json(io::IO, a)
 
     print(io, "}")
 end
+
+# Default to printing to STDOUT
+print_to_json{T}(a::T) = print_to_json(OUTPUT_STREAM, a)
 
 to_json(a) = sprint(print_to_json, a)
 
@@ -195,10 +200,10 @@ function parse(strng::String)
         end
         delta = m.offset + length(m.match)
         pos = pos + delta -1
-        if int_able(m.match) 
-            return int(m.match)
-        else 
-            return float64(m.match)
+        try
+            return parse_int(m.match)
+        catch
+            return parse_float(m.match)
         end
     end
 
@@ -271,14 +276,6 @@ function parse(strng::String)
         end
     end
 
-end
-
-function int_able(s::String)
-  ismatch(r"^(-)?\d+$", s)
-end
-
-function float_able(s::String)
-  ismatch(r"^(-)?\d+(\.\d+(e(-?)\d+)?)?$", s)
 end
 
 end

--- a/test/JSON.jl
+++ b/test/JSON.jl
@@ -1,6 +1,6 @@
-load("JSON")
+require("JSON")
 
-load("JSON/test/json_samples")
+require("JSON/test/json_samples")
 
 
 @assert JSON.parse(a) != nothing
@@ -52,3 +52,7 @@ u=JSON.parse(unicode)
 
 #Uncomment while doing timing tests
 #@time for i=1:100 ; JSON.parse(d) ; end
+
+# Printing an empty array or Dict shouldn't cause a BoundsError
+@assert JSON.to_json(ASCIIString[]) == "[]"
+@assert JSON.to_json(Dict()) == "{}"


### PR DESCRIPTION
- `load()` is no longer reliable. Switched to `require()`
- `print_to_json(io, a::Vector)` now works for empty vectors
- `print_to_json(a)` now defaults to printing to STDOUT
- Calls to `int_able()` were replaced with faster `parse_int()` calls
- Added tests to confirm that empty `Vector` and `Dict` printing works
