### PR TITLE
Change Vector to AbstractVector in print_to_json

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -27,7 +27,7 @@ function print_to_json(io::IO, a::Associative)
     print(io, "}") 
 end
 
-function print_to_json(io::IO, a::Vector)
+function print_to_json(io::IO, a::AbstractVector)
     print(io, "[")
     if length(a) > 0
         for x in a[1:end-1]


### PR DESCRIPTION
This will help with DataFrames compatibility (issue #10) and compatibility with other AbstractVector types.
