### PR TITLE
optimize `parse(IO)`

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -89,7 +89,7 @@ function parse(io::IO)
 
     while num_brackets_needed > 0
         c = char(read(io, Char))
-        obj = string(obj, c)
+        obj = obj * string(c)
 
         if c == open_bracket
             num_brackets_needed += 1


### PR DESCRIPTION
This is still embarrassingly slow... but this change shaves off an order of magnitude
