### PR TITLE
add const, use Any instead of a large type Union

### DIFF
--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -3,9 +3,9 @@
 module Parser
   
   # Types it may encounter
-  TYPES = Union(Dict, Array, String, Number, Bool, Nothing)
+  const TYPES = Any # Union(Dict, Array, String, Number, Bool, Nothing)
   # Types it may encounter as object keys
-  KEY_TYPES = Union(String)
+  const KEY_TYPES = Union(String)
   
   export parse
   


### PR DESCRIPTION
A huge union like `Union(Dict, Array, String, Number, Bool, Nothing)` is really more trouble than it's worth. Using `Any[]` instead is simpler and might even be faster. Also `TYPES` and `KEY_TYPES` should be `const`.
