### PR TITLE
instead of crashing on functions, print something a little more useful

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -39,7 +39,7 @@ function print(io::IO, a::Associative)
         Base.print(io, ':')
         JSON.print(io, value)
     end
-    Base.print(io, "}") 
+    Base.print(io, "}")
 end
 
 function print(io::IO, a::Union(AbstractVector,Tuple))
@@ -69,6 +69,10 @@ function print(io::IO, a)
         end
     end
     Base.print(io, "}")
+end
+
+function print(io::IO, f::Function)
+    Base.print(io, "\"function at ", f.fptr, "\"")
 end
 
 function print{T}(io::IO, a::Array{T, 2})


### PR DESCRIPTION
Right now, if you call `json(some_function)` you might get a stack overflow or you might get a nice message that says "ERROR: access to undefined reference". I've definitely even crashed Julia this way >.<

I don't know of any good way to really convert functions into json, but I think we should at least not error (or error in a more recoverable way). I figure this gives some useful information.
