### PR TITLE
Windows CI using AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,11 @@
 environment:
   matrix:
-  - JULIAVERSION: "x86/0.3/julia-0.3.0-prerelease-win32.exe"
-  - JULIAVERSION: "x64/0.3/julia-0.3.0-prerelease-win64.exe"
+  - JULIAVERSION: "win32"
+  - JULIAVERSION: "win64"
 
 install:
 # Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile($("http://s3.amazonaws.com/julialang/bin/winnt/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
+  - ps: (new-object net.webclient).DownloadFile($("http://status.julialang.org/download/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia
 


### PR DESCRIPTION
If you guys want to turn this on. There are actually some Windows test failures in master right now, slightly different between 32 bit https://ci.appveyor.com/project/tkelman/json-jl/build/1.0.7 and 64 bit https://ci.appveyor.com/project/tkelman/json-jl/build/1.0.8/job/bn9rkpoojoq6ciqb.
