### PR TITLE
Implement indents for printing JSON as per #65

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,3 +211,18 @@ close(io)
 @windows_only @assert haskey(JSON.parsefile(tmppath; use_mmap=false), "data")
 rm(tmppath)
 
+# check indented json has same final value as non indented
+
+fb = JSON.parse(facebook)
+fbjson1 = json(fb, 2)
+fbjson2 = json(fb)
+@assert JSON.parse(fbjson1) == JSON.parse(fbjson2)
+
+ev = JSON.parse(e)
+ejson1 = json(ev, 2)
+ejson2 = json(ev)
+@assert JSON.parse(ejson1) == JSON.parse(ejson2)
+
+# test symbols are treated as strings
+symtest =[:symbolarray => [:apple, :pear], :symbolsingleton => :hello]
+@assert JSON.json(symtest) == "{\"symbolarray\":[\"apple\",\"pear\"],\"symbolsingleton\":\"hello\"}"


### PR DESCRIPTION
This is quite a big change I know, but indent would be really useful when printing JSON as I asked earlier in #65.

I wasn't sure which branch to submit the pull request to so I've said master, but obviously I can create another pull request to different branch if that would be better.

This change shouldn't alter the default functionality, it just adds the `indent` keyword arguement to `json()` and `JSON.print()`.
