### PR TITLE
fix json(:symbol) returns "{}"

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -49,7 +49,7 @@ function print(io::IO, a::Associative)
     first = true
     for (key, value) in a
         first ? (first = false) : Base.print(io, ",")
-        JSON.print(io, key)
+        JSON.print(io, string(key))
         Base.print(io, ':')
         JSON.print(io, value)
     end


### PR DESCRIPTION
When i do `json(:a)`, it will return `"{}"`. i think it should return `"a"`. So i fix it.

And i change this line https://github.com/yfractal/JSON.jl/blob/master/src/JSON.jl#L48 to `JSON.print(io, key)`

Hope i did right and please review this, thanks :)
