### PR TITLE
only run appveyor on master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@ environment:
   - JULIAVERSION: "win32"
   - JULIAVERSION: "win64"
 
+branches:
+  only:
+    - master
+
 install:
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile($("http://status.julialang.org/download/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")


### PR DESCRIPTION
Apparently AppVeyor works with pull requests now. Might be a good idea to set it to only build for the master branch, until they sort out co-existing with Travis on status indicators.

cc @staticfloat @FeodorFitsner
