### PR TITLE
Convert to Int before indexing with Char in Array

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -65,10 +65,10 @@ end
 
 function print_escaped(io::IO, s::String)
     for c in s
-        c <= '\x7f' ? (unescaped[c+1]  ? Base.print(io, c) :
+        c <= '\x7f' ? (unescaped[int(c)+1]  ? Base.print(io, c) :
                        c == '\\'       ? Base.print(io, "\\\\") :
                        c == '"'        ? Base.print(io, "\\\"") :
-                       8 <= c <= 10    ? Base.print(io, '\\', "btn"[c-7]) :
+                       8 <= c <= 10    ? Base.print(io, '\\', "btn"[int(c)-7]) :
                        c == '\f'       ? Base.print(io, "\\f") :
                        c == '\r'       ? Base.print(io, "\\r") :
                                          Base.print(io, "\\u", hex(c, 4))) :


### PR DESCRIPTION
Regression fix from https://github.com/JuliaLang/julia/pull/8816
Fixes #84 

This seems like an obvious fix to me. We could reenable indexing with `Char`, but it seems more clear to convert manually when we need it in cases like this.
