### PR TITLE
Simplify ordered dictionary loading code

### DIFF
--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -2,13 +2,10 @@ module Parser #JSON
 
 using Compat
 
-_HAVE_ORDERED_DICT = try
-    import DataStructures
-    true
-end
-if _HAVE_ORDERED_DICT
+#Define ordered dictionary from DataStructures if present
+try
     import DataStructures.OrderedDict
-else
+catch
     function OrderedDict(key_types, types)
         Base.warn_once("Ordered JSON object parsing is not available.\nRun `Pkg.add(\"DataStructures.jl\")` to enable.")
         Dict{key_types, types}()


### PR DESCRIPTION
`try/catch` no longer returns `false` when no `catch` block is defined and an exception is thrown.

This change should be safe for both Julia 0.3 and 0.4-dev.

Ref: JuliaLang/julia#9320
