### PR TITLE
Adding JSON macro strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ JSON.json(j)
 #  "{\"an_array\":[\"string\",9],\"a_number\":5.0}"
 ```
 
+### Macro Strings
+
+`JSON` and `J` can be used to embed JSON data directly into source code:
+
+```julia
+basic_dict = JSON"""
+{
+  "a_number" : 5.0,
+  "an_array" : ["string", 9]
+}
+"""
+```
+
+
+```julia
+basic_dict = J"{'a_number' : 5.0, 'an_array' : ['string', 9]}"
+```
+
 ## Documentation
 
 ```julia

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -2,7 +2,7 @@ module JSON
 
 using Compat
 
-export json, @J_str, @JSON_str, @JSON_ORDERED_str # returns a compact (or indented) JSON representation as a String
+export json, @J_str, @JSON_mstr, @JSON_ORDERED_mstr # returns a compact (or indented) JSON representation as a String
 
 include("Parser.jl")
 
@@ -283,8 +283,8 @@ function parsefile(filename::AbstractString; ordered::Bool=false, use_mmap=true)
 end
 
 # Macros
-macro JSON_str(arg::AbstractString) parse(arg) end
-macro JSON_ORDERED_str(arg::AbstractString) parse(arg, ordered=true) end
-macro J_str(arg::AbstractString) parse(arg, quote_char='\'') end # convenience intented for short single quoted json data
+macro JSON_mstr(arg::AbstractString) parse(arg) end
+macro JSON_ORDERED_mstr(arg::AbstractString) parse(arg, ordered=true) end
+macro J_str(arg::AbstractString) parse(arg, single_quote=true) end # convenience intented for short single quoted json data
 
 end # module

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -2,7 +2,7 @@ module JSON
 
 using Compat
 
-export json # returns a compact (or indented) JSON representation as a String
+export json, @J_str, @JSON_str, @JSON_ORDERED_str # returns a compact (or indented) JSON representation as a String
 
 include("Parser.jl")
 
@@ -17,8 +17,8 @@ type State{I}
     indentlen::Int
     prefix::AbstractString
     otype::Array{Bool, 1}
-    State(indentstep::Int) = new(indentstep, 
-                                 0, 
+    State(indentstep::Int) = new(indentstep,
+                                 0,
                                  "",
                                  Bool[])
 end
@@ -282,5 +282,9 @@ function parsefile(filename::AbstractString; ordered::Bool=false, use_mmap=true)
     end
 end
 
-end # module
+# Macros
+macro JSON_str(arg::AbstractString) parse(arg) end
+macro JSON_ORDERED_str(arg::AbstractString) parse(arg, ordered=true) end
+macro J_str(arg::AbstractString) parse(arg, quote_char='\'') end # convenience intented for short single quoted json data
 
+end # module

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -318,9 +318,10 @@ function parse_number{T<:AbstractString}(ps::ParserState{T})
     end
 end
 
-function parse(str::AbstractString; ordered::Bool=false, quote_char::Char='"')
+function parse(str::AbstractString; ordered::Bool=false, single_quote::Bool=false)
     pos::Int = 1
     len::Int = endof(str)
+    quote_char::Char = single_quote ? '\'' : '\"'
     len < 1 && return
     ordered && !_HAVE_DATASTRUCTURES && error("DataStructures package required for ordered parsing: try `Pkg.add(\"DataStructures\")`")
     parse_value(ParserState(str, pos, len), ordered, quote_char)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,3 +235,21 @@ let iob = IOBuffer()
     JSON.print(iob, t109(1))
     @test get(JSON.parse(takebuf_string(iob)), "i", 0) == 1
 end
+
+# Tests for Macro strings
+
+let mstr_test = @compat Dict("a" => 1)
+    @test mstr_test == JSON"""{"a":1}"""
+    @test mstr_test == J"{'a':1}"
+    @test JSON_ORDERED"""{"x": 3}""" == DataStructures.OrderedDict{String,Any}([("x",3)])
+
+    @test (@compat Dict("a_number" => 5, "an_array" => ["string"; 9]) ) == J"{'a_number' : 5, 'an_array' : ['string', 9] }"
+
+    @test JSON"""
+    {
+      "a_number" : 5.0,
+      "an_array" : ["string", 9]
+    }
+    """ == (@compat Dict("a_number" => 5, "an_array" => ["string"; 9]) )
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,3 +253,11 @@ let mstr_test = @compat Dict("a" => 1)
     """ == (@compat Dict("a_number" => 5, "an_array" => ["string"; 9]) )
 
 end
+
+# Test Leniant
+let tmp = JSON.parse("{\"a\": NaN}")
+    @test isnan(tmp["a"]) == true 
+end
+
+
+


### PR DESCRIPTION
Basic implementation of JSON macro strings in addition to allowing parsing of non-standard JSON using single quotes `'` around string values. Only single or double quote chars can be used in a single JSON string. 

This is based on the discussion towards the end of [Julia Issue #6739](https://github.com/JuliaLang/julia/issues/6739). 

I've added tests and updated the documentation as well. 
