### PR TITLE
[WIP] Updated json string literal based on elcritch's work

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,16 @@ provide a desired ordering.  For example, if you `import DataStructures`
 package](https://github.com/JuliaLang/DataStructures.jl) is
 installed), you can pass `dicttype=DataStructures.OrderedDict` to
 maintain the insertion order of the items in the object.
+
+### Macro Strings
+
+`json"..."` can be used to embed JSON data directly into source code:
+
+```julia
+basic_dict = json"""
+{
+  "a_number" : 5.0,
+  "an_array" : ["string", 9]
+}
+"""
+```

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -6,7 +6,7 @@ using Compat
 
 import Base.colon
 
-export json # returns a compact (or indented) JSON representation as a string
+export json, @json_str, @json_mstr   # returns a compact (or indented) JSON representation as a string
 
 include("Parser.jl")
 
@@ -288,5 +288,18 @@ function parsefile{T<:Associative}(filename::AbstractString; dicttype::Type{T}=D
         JSON.parse(s; dicttype=dicttype)
     end
 end
+
+# Macros 
+str_helper(arg) = parse(arg)
+# I couldn't figure out a way to append the type.
+# The following doesn't work.
+## str_helper(arg, typ) = :(parse($arg, dicttype=eval(symbol($typ))))
+
+macro json_mstr(args...) 
+    str_helper(args...) 
+end
+macro json_str(args...) 
+    str_helper(args...) 
+end 
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -266,3 +266,18 @@ end
 
 # Check that printing to the default STDOUT doesn't fail
 JSON.print(["JSON.jl tests pass!"],1)
+
+# Tests for Macro strings
+
+let mstr_test = @compat Dict("a" => 1)
+    @test mstr_test == json"""{"a":1}"""
+    @test json"""{"x": 3}"""OrderedDict == DataStructures.OrderedDict{String,Any}([("x",3)])
+
+    @test json"""
+    {
+      "a_number" : 5.0,
+      "an_array" : ["string", 9]
+    }
+    """ == (@compat Dict("a_number" => 5.0, "an_array" => ["string"; 9]) )
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,7 +271,8 @@ JSON.print(["JSON.jl tests pass!"],1)
 
 let mstr_test = @compat Dict("a" => 1)
     @test mstr_test == json"""{"a":1}"""
-    @test json"""{"x": 3}"""OrderedDict == DataStructures.OrderedDict{String,Any}([("x",3)])
+    # Doesn't work:
+    ## @test json"""{"x": 3}"""OrderedDict == DataStructures.OrderedDict{String,Any}([("x",3)])     
 
     @test json"""
     {


### PR DESCRIPTION
The aim of this PR is to update and simplify @elcritch's PR https://github.com/JuliaLang/JSON.jl/pull/113. 

The single-quote option is removed. There's also no option to pass the dicttype. I tried using a trailing argument for this, but I couldn't find an `eval` option that worked. 

It's marked as WIP because there's some extra junk in there for my failed tries to get dicttype to work. Someone else may have a suggestion. In any case, it needs to be cleaned up.
