### PR TITLE
adds test and workaround for 0.5 issue with printing Float32s

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -149,6 +149,12 @@ function _writejson(io::IO, state::State, s::AbstractString)
     Base.print(io, '"')
 end
 
+# workaround for issue in Julia 0.5.x where Float32 values are printed as
+# 3.4f-5 instead of 3.4e-5
+if v"0.5-" <= VERSION < v"0.6-"
+    _writejson(io::IO, state::State, s::Float32) = _writejson(io, state, Float64(s))
+end
+
 function _writejson(io::IO, state::State, s::Union{Integer, AbstractFloat})
     if isnan(s) || isinf(s)
         Base.print(io, "null")

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -151,7 +151,7 @@ end
 
 # workaround for issue in Julia 0.5.x where Float32 values are printed as
 # 3.4f-5 instead of 3.4e-5
-if v"0.5-" <= VERSION < v"0.6-"
+if v"0.5-" <= VERSION < v"0.6.0-dev.788"
     _writejson(io::IO, state::State, s::Float32) = _writejson(io, state, Float64(s))
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,7 +252,7 @@ end
 @test sprint(JSON.print, [Inf]) == "[null]"
 
 # check for issue #163
-@test JSON.parse(json(2.1f-8)) == Float64(2.1f-8)
+@test isapprox(JSON.parse(json(Float32(2.1e-8))), 2.1e-8)
 
 # Check printing of more exotic objects
 if VERSION < v"0.5.0-dev+2396"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,7 +252,7 @@ end
 @test sprint(JSON.print, [Inf]) == "[null]"
 
 # check for issue #163
-@test isapprox(JSON.parse(json(Float32(2.1e-8))), 2.1e-8)
+@test Float32(JSON.parse(json(2.1f-8))) == 2.1f-8
 
 # Check printing of more exotic objects
 if VERSION < v"0.5.0-dev+2396"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,6 +251,9 @@ end
 @test sprint(JSON.print, [NaN]) == "[null]"
 @test sprint(JSON.print, [Inf]) == "[null]"
 
+# check for issue #163
+@test JSON.parse(json(2.1f-8)) == Float64(2.1f-8)
+
 # Check printing of more exotic objects
 if VERSION < v"0.5.0-dev+2396"
     # Test broken in v0.5, code is using internal structure of Function type!


### PR DESCRIPTION
Fixes #163 

I'm not super familiar with how the JSON serialization is expected to work, particularly how strict it's supposed to be with round-tripping floating-point numbers. LMK if just converting to a Float64 for JSON serialization is a bad idea.

Related:
JuliaLang/julia#17720
JuliaLang/julia#18053
JuliaLang/julia#18682
spencerlyon2/PlotlyJS.jl#78