### PR TITLE
Support for `Nullable`

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -175,6 +175,10 @@ function _writejson(io::IO, state::State, a::Nullable)
     end
 end
 
+function _writejson(io::IO, state::State, c::Char)
+    _writejson(io, state, string(c))
+end
+
 function _writejson(io::IO, state::State, a::Associative)
     if length(a) == 0
         Base.print(io, "{}")

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -56,6 +56,7 @@ if VERSION < v"0.5.0-dev+2396"
     lower(f::Function) = "function at $(f.fptr)"
 end
 
+lower(c::Char) = string(c)
 lower(d::DataType) = string(d)
 lower(m::Module) = throw(ArgumentError("cannot serialize Module $m as JSON"))
 
@@ -173,10 +174,6 @@ function _writejson(io::IO, state::State, a::Nullable)
     else
         _writejson(io, state, get(a))
     end
-end
-
-function _writejson(io::IO, state::State, c::Char)
-    _writejson(io, state, string(c))
 end
 
 function _writejson(io::IO, state::State, a::Associative)

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -167,6 +167,14 @@ function _writejson(io::IO, state::State, n::Void)
     Base.print(io, "null")
 end
 
+function _writejson(io::IO, state::State, a::Nullable)
+    if isnull(a)
+        Base.print(io, "null")
+    else
+        _writejson(io, state, get(a))
+    end
+end
+
 function _writejson(io::IO, state::State, a::Associative)
     if length(a) == 0
         Base.print(io, "{}")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,12 +252,15 @@ end
 @test sprint(JSON.print, [Inf]) == "[null]"
 
 # check Nullables are printed correctly
+@test sprint(JSON.print, [Nullable()]) == "[null]"
 @test sprint(JSON.print, [Nullable{Int64}()]) == "[null]"
 @test sprint(JSON.print, [Nullable{Int64}(Int64(1))]) == "[1]"
 
 # check Chars
 @test json('a') == "\"a\""
 @test json('\\') == "\"\\\\\""
+@test json('\n') == "\"\\n\""
+@test json('🍩') =="\"🍩\""
 
 # check for issue #163
 @test Float32(JSON.parse(json(2.1f-8))) == 2.1f-8

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -255,6 +255,10 @@ end
 @test sprint(JSON.print, [Nullable{Int64}()]) == "[null]"
 @test sprint(JSON.print, [Nullable{Int64}(Int64(1))]) == "[1]"
 
+# check Chars
+@test json('a') == "\"a\""
+@test json('\\') == "\"\\\\\""
+
 # check for issue #163
 @test Float32(JSON.parse(json(2.1f-8))) == 2.1f-8
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,7 +253,7 @@ end
 
 # check Nullables are printed correctly
 @test sprint(JSON.print, [Nullable{Int64}()]) == "[null]"
-@test sprint(JSON.print, [Nullable{Int64}(1)]) == "[1]"
+@test sprint(JSON.print, [Nullable{Int64}(Int64(1))]) == "[1]"
 
 # check for issue #163
 @test Float32(JSON.parse(json(2.1f-8))) == 2.1f-8

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -251,6 +251,10 @@ end
 @test sprint(JSON.print, [NaN]) == "[null]"
 @test sprint(JSON.print, [Inf]) == "[null]"
 
+# check Nullables are printed correctly
+@test sprint(JSON.print, [Nullable{Int64}()]) == "[null]"
+@test sprint(JSON.print, [Nullable{Int64}(1)]) == "[1]"
+
 # check for issue #163
 @test Float32(JSON.parse(json(2.1f-8))) == 2.1f-8
 


### PR DESCRIPTION
Added `_writejson` method for `Nullable` values. Maps to JSON `null` if
value is null.

(edit by TotalVerb: fixes #132)