### PR TITLE
adds lowering fallback for Real subtypes that converts to Float64

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -59,6 +59,7 @@ end
 lower(c::Char) = string(c)
 lower(d::DataType) = string(d)
 lower(m::Module) = throw(ArgumentError("cannot serialize Module $m as JSON"))
+lower(x::Real) = Float64(x)
 
 const INDENT=true
 const NOINDENT=false

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 DataStructures
+FixedPointNumbers

--- a/test/lowering.jl
+++ b/test/lowering.jl
@@ -15,3 +15,6 @@ JSON.lower{T}(v::Type151{T}) = Dict(:type => T, :value => v.x)
 @test JSON.parse(JSON.json(Type151(1.0))) == Dict(
     "type" => "Float64",
     "value" => 1.0)
+
+fixednum = Fixed{Int16, 15}(0.1234)
+@test JSON.parse(JSON.json(fixednum)) == Float64(fixednum)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using JSON
 using Base.Test
 using Compat
 import DataStructures
+import FixedPointNumbers: Fixed
 
 include("json-checker.jl")
 include(joinpath(dirname(@__FILE__),"json_samples.jl"))


### PR DESCRIPTION
My main use case for this is so that PlotlyJS.jl is able to plot
my vectors of fixed-point numbers, which come up a lot when loading
audio files.