### PR TITLE
support 0-dim arrays

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -312,6 +312,9 @@ function show_json{T,n}(io::SC, s::CS, A::AbstractArray{T,n})
     end_array(io)
 end
 
+# special case for 0-dimensional arrays
+show_json{T}(io::SC, s::CS, A::AbstractArray{T,0}) = show_json(io, s, A[])
+
 show_json(io::SC, s::CS, a) = show_json(io, s, lower(a))
 
 # Fallback show_json for non-SC types

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -87,4 +87,7 @@ let filename = tempname()
     rm(filename)
 end
 
+# issue #184: serializing a 0-dimensional array
+@test sprint(JSON.show_json, JSON.StandardSerialization(), view([184], 1)) == "184"
+
 end


### PR DESCRIPTION
Currently, 0-dimensional arrays are not properly handled by the generic `_writejson()`.
The proposed specialized method just writes the first (and only) element.