### PR TITLE
Use StringVector instead of Vector{UInt8}

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.17.0
+Compat 0.24.0

--- a/src/specialized.jl
+++ b/src/specialized.jl
@@ -1,4 +1,5 @@
 # Specialized functions for increased performance when JSON is in-memory
+using Compat: StringVector
 
 function parse_string(ps::MemoryParserState)
     # "Dry Run": find length of string so we can allocate the right amount of
@@ -6,7 +7,7 @@ function parse_string(ps::MemoryParserState)
     fastpath, len = predict_string(ps)
 
     # Now read the string itself
-    b = Vector{UInt8}(len)
+    b = StringVector(len)
 
     # Fast path occurs when the string has no escaped characters. This is quite
     # often the case in real-world data, especially when keys are short strings.


### PR DESCRIPTION
This avoids extra allocation and copying for the in-memory string
parsing.

Fixes #197.

(As far as I can tell, the other uses of `Vector{UInt8}` are not passed to the `String` constructor, so do not require this change.)