### PR TITLE
Support Enums

### DIFF
--- a/test/lowering.jl
+++ b/test/lowering.jl
@@ -27,4 +27,14 @@ JSON.lower{T}(v::Type151{T}) = Dict(:type => T, :value => v.x)
 fixednum = Fixed{Int16, 15}(0.1234)
 @test JSON.parse(JSON.json(fixednum)) == Float64(fixednum)
 
+# test that the default string-serialization of enums can be overriden by
+# `lower` if needed
+@enum Fruit apple orange banana
+JSON.lower(x::Fruit) = string("Fruit: ", x)
+@test JSON.json(apple) == "\"Fruit: apple\""
+
+@enum Vegetable carrot tomato potato
+JSON.lower(x::Vegetable) = Dict(string(x) => Int(x))
+@test JSON.json(potato) == "{\"potato\":2}"
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,6 +264,12 @@ end
 @test json('\n') == "\"\\n\""
 @test json('🍩') =="\"🍩\""
 
+# check enums
+@enum Animal zebra aardvark horse
+@test json(zebra) == "\"zebra\""
+@test json([aardvark, horse, Dict("z" => zebra)]) ==
+    "[\"aardvark\",\"horse\",{\"z\":\"zebra\"}]"
+
 # check for issue #163
 @test Float32(JSON.parse(json(2.1f-8))) == 2.1f-8
 


### PR DESCRIPTION
Fixes #201. I made some unrelated changes also:

- The `JSONPrimitive` constant is not used anywhere and so I've deleted it.
- To avoid excess allocations in lowering `Char` and `Type`, they're now lowered to themselves and printed directly by the string-like `show_json` (previously, we were doing that only for symbols and strings). The same treatment applies to `Enum`; users can still define `lower` to customize the printing if necessary (see test/lowering.jl). We can do this with dates too, but that's easier to do once 0.4 support is dropped.