### PR TITLE
RFC (don't merge) Send every singleton to nothing

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -38,9 +38,8 @@ primitives.
 function lower(a)
     if nfields(typeof(a)) > 0
         CompositeTypeWrapper(a)
-    else
-        error("Cannot serialize type $(typeof(a))")
     end
+    # singletons are sent to nothing
 end
 
 lower(s::Base.Dates.TimeType) = string(s)


### PR DESCRIPTION
This is a possible solution to #203. I don't particularly like this solution; I think it should not be JSON's responsibility to guess that all singletons should turn into `null`, but I can't think of a better one for #203.