### PR TITLE
Lower `AbstractSet` through `collect`

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -43,14 +43,13 @@ function lower(a)
     end
 end
 
-lower(s::Base.Dates.TimeType) = string(s)
-
 # To avoid allocating an intermediate string, we directly define `show_json`
 # for this type instead of lowering it to a string first (which would
 # allocate). However, the `show_json` method does call `lower` so as to allow
 # users to change the lowering of their `Enum` or even `AbstractString`
 # subtypes if necessary.
-const IsPrintedAsString = Union{Char, Type, AbstractString, Enum, Symbol}
+const IsPrintedAsString = Union{
+    Dates.TimeType, Char, Type, AbstractString, Enum, Symbol}
 lower(x::IsPrintedAsString) = x
 
 lower(m::Module) = throw(ArgumentError("cannot serialize Module $m as JSON"))

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -54,6 +54,7 @@ lower(x::IsPrintedAsString) = x
 
 lower(m::Module) = throw(ArgumentError("cannot serialize Module $m as JSON"))
 lower(x::Real) = Float64(x)
+lower(x::Base.AbstractSet) = collect(x)
 
 """
 Abstract supertype of all JSON and JSON-like structural writer contexts.

--- a/test/standard-serializer.jl
+++ b/test/standard-serializer.jl
@@ -57,3 +57,8 @@ end
     #Multidimensional arrays
     @test json([0 1; 2 0]) == "[[0,2],[1,0]]"
 end
+
+@testset "Sets" begin
+    @test json(Set()) == "[]"
+    @test json(Set([1, 2])) in ["[1,2]", "[2,1]"]
+end


### PR DESCRIPTION
Fix #196.

This has been requested for a while and makes sense to do. The first commit is unrelated but just a simplification to the code with no functional change.

@oyd11, please review and confirm that this addresses your use case.