### PR TITLE
Fix the deprecation warnings

### DIFF
--- a/bench/micro.jl
+++ b/bench/micro.jl
@@ -1,4 +1,5 @@
 # JSON Microbenchmarks
+# 0.6 required for running benchmarks
 
 using JSON
 using BenchmarkTools
@@ -8,13 +9,13 @@ const suite = BenchmarkGroup()
 suite["print"] = BenchmarkGroup(["serialize"])
 suite["pretty-print"] = BenchmarkGroup(["serialize"])
 
-immutable CustomListType
+struct CustomListType
     x::Int
     y::Float64
     z::Union{CustomListType, Void}
 end
 
-immutable CustomTreeType
+struct CustomTreeType
     x::String
     y::Union{CustomTreeType, Void}
     z::Union{CustomTreeType, Void}

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -18,16 +18,18 @@ isjsondigit(b::UInt8) = DIGIT_ZERO ≤ b ≤ DIGIT_NINE
 
 @compat abstract type ParserState end
 
-type MemoryParserState <: ParserState
+eval(Expr(:type, true, :(MemoryParserState <: ParserState),
+quote
     utf8data::Vector{UInt8}
     s::Int
-end
+end))
 
-type StreamingParserState{T <: IO} <: ParserState
+eval(Expr(:type, true, :(StreamingParserState{T <: IO} <: ParserState),
+quote
     io::T
     cur::UInt8
     used::Bool
-end
+end))
 StreamingParserState{T <: IO}(io::T) = StreamingParserState{T}(io, 0x00, true)
 
 """

--- a/src/Serializations.jl
+++ b/src/Serializations.jl
@@ -14,17 +14,19 @@ A `Serialization` defines how objects are lowered to JSON format.
 """
 @compat abstract type Serialization end
 
-"""
+@compat abstract type CommonSerialization <: Serialization end
+@doc """
 The `CommonSerialization` comes with a default set of rules for serializing
 Julia types to their JSON equivalents. Additional rules are provided either by
 packages explicitly defining `JSON.show_json` for this serialization, or by the
 `JSON.lower` method. Most concrete implementations of serializers should subtype
 `CommonSerialization`, unless it is desirable to bypass the `lower` system, in
 which case `Serialization` should be subtyped.
-"""
-@compat abstract type CommonSerialization <: Serialization end
+""" CommonSerialization
 
-"""
+eval(Expr(:type, false, :(StandardSerialization <: CommonSerialization),
+          quote end))
+@doc """
 The `StandardSerialization` defines a common, standard JSON serialization format
 that is optimized to:
 
@@ -34,7 +36,6 @@ that is optimized to:
 All serializations defined for `CommonSerialization` are inherited by
 `StandardSerialization`. It is therefore generally advised to add new
 serialization behaviour to `CommonSerialization`.
-"""
-immutable StandardSerialization <: CommonSerialization end
+""" StandardSerialization
 
 end

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -5,16 +5,17 @@ using ..Common
 using ..Serializations: Serialization, StandardSerialization,
                         CommonSerialization
 
-"""
+eval(Expr(:type, false, :(CompositeTypeWrapper{T}),
+quote
+    wrapped::T
+    fns::Vector{Symbol}
+end))
+@doc """
 Internal JSON.jl implementation detail; do not depend on this type.
 
 A JSON primitive that wraps around any composite type to enable `Dict`-like
 serialization.
-"""
-immutable CompositeTypeWrapper{T}
-    wrapped::T
-    fns::Vector{Symbol}
-end
+""" CompositeTypeWrapper
 CompositeTypeWrapper(x) = CompositeTypeWrapper(x, fieldnames(x))
 
 """
@@ -75,39 +76,42 @@ to the stream.
 """
 @compat abstract type JSONContext <: StructuralContext end
 
-"""
-Internal implementation detail.
-
-Keeps track of the current location in the array or object, which winds and
-unwinds during serialization.
-"""
-type PrettyContext{T<:IO} <: JSONContext
+eval(Expr(:type, true, :(PrettyContext{T<:IO} <: JSONContext),
+quote
     io::T
     step::Int     # number of spaces to step
     state::Int    # number of steps at present
     first::Bool   # whether an object/array was just started
-end
+end))
+@doc """
+Internal implementation detail.
+
+Keeps track of the current location in the array or object, which winds and
+unwinds during serialization.
+""" PrettyContext
 PrettyContext(io::IO, step) = PrettyContext(io, step, 0, false)
 
-"""
+eval(Expr(:type, true, :(CompactContext{T<:IO} <: JSONContext),
+quote
+    io::T
+    first::Bool
+end))
+@doc """
 Internal implementation detail.
 
 For compact printing, which in JSON is fully recursive.
-"""
-type CompactContext{T<:IO} <: JSONContext
-    io::T
-    first::Bool
-end
+""" CompactContext
 CompactContext(io::IO) = CompactContext(io, false)
 
-"""
+eval(Expr(:type, false, :(StringContext{T<:IO} <: IO),
+quote
+    io::T
+end))
+@doc """
 Internal implementation detail.
 
 Implements an IO context safe for printing into JSON strings.
-"""
-immutable StringContext{T<:IO} <: IO
-    io::T
-end
+""" StringContext
 
 # These make defining additional methods on `show_json` easier.
 const CS = CommonSerialization

--- a/test/lowering.jl
+++ b/test/lowering.jl
@@ -12,9 +12,9 @@ end
 @test JSON.json(:x) == "\"x\""
 @test_throws ArgumentError JSON.json(Base)
 
-immutable Type151{T}
+eval(Expr(:type, false, :(Type151{T}), quote
     x::T
-end
+end))
 
 @test JSON.parse(JSON.json(Type151)) == string(Type151)
 

--- a/test/regression/issue109.jl
+++ b/test/regression/issue109.jl
@@ -1,6 +1,7 @@
-type t109
+eval(Expr(:type, true, :t109,
+quote
     i::Int
-end
+end))
 
 let iob = IOBuffer()
     JSON.print(iob, t109(1))

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -20,7 +20,7 @@ function sprint_kwarg(f, args...; kwargs...)
 end
 
 # issue #168: Print NaN and Inf as Julia would
-immutable NaNSerialization <: CS end
+eval(Expr(:type, false, :(NaNSerialization <: CS), quote end))
 JSON.show_json(io::SC, ::NaNSerialization, f::AbstractFloat) =
     Base.print(io, f)
 
@@ -42,10 +42,11 @@ JSON.show_json(io::SC, ::NaNSerialization, f::AbstractFloat) =
 """
 
 # issue #170: Print JavaScript functions directly
-immutable JSSerialization <: CS end
-immutable JSFunction
+eval(Expr(:type, false, :(JSSerialization <: CS), quote end))
+eval(Expr(:type, false, :JSFunction,
+quote
     data::String
-end
+end))
 
 function JSON.show_json(io::SC, ::JSSerialization, f::JSFunction)
     first = true
@@ -73,7 +74,7 @@ end
 """
 
 # test serializing a type without any fields
-immutable SingletonType end
+eval(Expr(:type, false, :SingletonType, quote end))
 @test_throws ErrorException json(SingletonType())
 
 # test printing to STDOUT


### PR DESCRIPTION
Since benchmarks are not a part of JSON itself, I didn't bother trying to support both 0.5 and 0.6 on them; this PR makes 0.6 is required to run the benchmarks.

This is a really ugly PR but luckily only a temporary solution until we can drop support for 0.5.