### PR TITLE
Support Pair, serializing as an object

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -282,6 +282,12 @@ function show_json(io::SC, s::CS, a::Associative)
     end_object(io)
 end
 
+function show_json(io::SC, s::CS, kv::Pair)
+    begin_object(io)
+    show_pair(io, s, kv)
+    end_object(io)
+end
+
 function show_json(io::SC, s::CS, x::CompositeTypeWrapper)
     begin_object(io)
     fns = x.fns

--- a/test/standard-serializer.jl
+++ b/test/standard-serializer.jl
@@ -61,7 +61,7 @@ end
 @testset "Pairs" begin
     @test json(1 => 2) == "{\"1\":2}"
     @test json(:foo => 2) == "{\"foo\":2}"
-    @test json([1, 2] => [3, 4]) == "{\"$[1, 2]\":[3,4]}"
+    @test json([1, 2] => [3, 4]) == "{\"$([1, 2])\":[3,4]}"
     @test json([1 => 2]) == "[{\"1\":2}]"
 end
 

--- a/test/standard-serializer.jl
+++ b/test/standard-serializer.jl
@@ -61,7 +61,7 @@ end
 @testset "Pairs" begin
     @test json(1 => 2) == "{\"1\":2}"
     @test json(:foo => 2) == "{\"foo\":2}"
-    @test json([1, 2] => [3, 4]) == "{\"[1, 2]\":[3,4]}"
+    @test json([1, 2] => [3, 4]) == "{\"$[1, 2]\":[3,4]}"
     @test json([1 => 2]) == "[{\"1\":2}]"
 end
 

--- a/test/standard-serializer.jl
+++ b/test/standard-serializer.jl
@@ -58,6 +58,13 @@ end
     @test json([0 1; 2 0]) == "[[0,2],[1,0]]"
 end
 
+@testset "Pairs" begin
+    @test json(1 => 2) == "{\"1\":2}"
+    @test json(:foo => 2) == "{\"foo\":2}"
+    @test json([1, 2] => [3, 4]) == "{\"[1, 2]\":[3,4]}"
+    @test json([1 => 2]) == "[{\"1\":2}]"
+end
+
 @testset "Sets" begin
     @test json(Set()) == "[]"
     @test json(Set([1, 2])) in ["[1,2]", "[2,1]"]


### PR DESCRIPTION
@quinnj, @kmsquire please review if you have the time. I implemented this as `show_json` instead of `lower` because allocating `Dict`s is expensive...

Close #106.