### PR TITLE
show_json(CompTypeWrapper): access fields by name

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -290,9 +290,8 @@ end
 
 function show_json(io::SC, s::CS, x::CompositeTypeWrapper)
     begin_object(io)
-    fns = x.fns
-    for k in 1:length(fns)
-        show_pair(io, s, fns[k], getfield(x.wrapped, k))
+    for fn in x.fns
+        show_pair(io, s, fn, getfield(x.wrapped, fn))
     end
     end_object(io)
 end


### PR DESCRIPTION
This allows reusing `CompositeTypeWrapper` for defining custom `lower()` methods that exclude certain fields from serialization.