### PR TITLE
Unescape solidus in tests, and other deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat 0.24.0
+Compat 0.30.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5
-Compat 0.30.0
+Compat 0.31.0

--- a/bench/bench.jl
+++ b/bench/bench.jl
@@ -16,7 +16,7 @@ function bench(f, simulate=false)
         JSON.parsefile(fp)
         toq()
     else
-        data = readstring(fp)
+        data = read(fp, String)
         tic()
         JSON.Parser.parse(data)
         toq()

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -5,6 +5,10 @@ module Common
 
 using Compat
 
+# The expression head to use for constructing types.
+# TODO: Remove this hack when 0.5 support is dropped.
+const STRUCTHEAD = VERSION < v"0.7.0-DEV.1263" ? :type : :struct
+
 include("bytes.jl")
 include("errors.jl")
 

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -18,13 +18,13 @@ isjsondigit(b::UInt8) = DIGIT_ZERO ≤ b ≤ DIGIT_NINE
 
 @compat abstract type ParserState end
 
-eval(Expr(:type, true, :(MemoryParserState <: ParserState),
+eval(Expr(Common.STRUCTHEAD, true, :(MemoryParserState <: ParserState),
 quote
     utf8data::Vector{UInt8}
     s::Int
 end))
 
-eval(Expr(:type, true, :(StreamingParserState{T <: IO} <: ParserState),
+eval(Expr(Common.STRUCTHEAD, true, :(StreamingParserState{T <: IO} <: ParserState),
 quote
     io::T
     cur::UInt8

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -390,7 +390,7 @@ end
 function parsefile{T<:Associative}(filename::AbstractString; dicttype::Type{T}=Dict{String, Any}, use_mmap=true)
     sz = filesize(filename)
     open(filename) do io
-        s = use_mmap ? String(Mmap.mmap(io, Vector{UInt8}, sz)) : readstring(io)
+        s = use_mmap ? String(Mmap.mmap(io, Vector{UInt8}, sz)) : read(io, String)
         parse(s; dicttype=dicttype)
     end
 end

--- a/src/Serializations.jl
+++ b/src/Serializations.jl
@@ -8,6 +8,7 @@ implementations, as they relate to JSON.
 module Serializations
 
 using Compat
+using ..Common
 
 """
 A `Serialization` defines how objects are lowered to JSON format.
@@ -24,7 +25,7 @@ packages explicitly defining `JSON.show_json` for this serialization, or by the
 which case `Serialization` should be subtyped.
 """ CommonSerialization
 
-eval(Expr(:type, false, :(StandardSerialization <: CommonSerialization),
+eval(Expr(Common.STRUCTHEAD, false, :(StandardSerialization <: CommonSerialization),
           quote end))
 @doc """
 The `StandardSerialization` defines a common, standard JSON serialization format

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -16,7 +16,7 @@ Internal JSON.jl implementation detail; do not depend on this type.
 A JSON primitive that wraps around any composite type to enable `Dict`-like
 serialization.
 """ CompositeTypeWrapper
-CompositeTypeWrapper(x) = CompositeTypeWrapper(x, fieldnames(x))
+CompositeTypeWrapper(x) = CompositeTypeWrapper(x, fieldnames(typeof(x)))
 
 """
     lower(x)

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -314,7 +314,7 @@ Serialize a multidimensional array to JSON in column-major format. That is,
 """
 function show_json{T,n}(io::SC, s::CS, A::AbstractArray{T,n})
     begin_array(io)
-    newdims = ntuple(_ -> :, Val{n - 1})
+    newdims = ntuple(_ -> :, n - 1)
     for j in indices(A, n)
         show_element(io, s, view(A, newdims..., j))
     end

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -5,7 +5,7 @@ using ..Common
 using ..Serializations: Serialization, StandardSerialization,
                         CommonSerialization
 
-eval(Expr(:type, false, :(CompositeTypeWrapper{T}),
+eval(Expr(Common.STRUCTHEAD, false, :(CompositeTypeWrapper{T}),
 quote
     wrapped::T
     fns::Vector{Symbol}
@@ -76,7 +76,7 @@ to the stream.
 """
 @compat abstract type JSONContext <: StructuralContext end
 
-eval(Expr(:type, true, :(PrettyContext{T<:IO} <: JSONContext),
+eval(Expr(Common.STRUCTHEAD, true, :(PrettyContext{T<:IO} <: JSONContext),
 quote
     io::T
     step::Int     # number of spaces to step
@@ -91,7 +91,7 @@ unwinds during serialization.
 """ PrettyContext
 PrettyContext(io::IO, step) = PrettyContext(io, step, 0, false)
 
-eval(Expr(:type, true, :(CompactContext{T<:IO} <: JSONContext),
+eval(Expr(Common.STRUCTHEAD, true, :(CompactContext{T<:IO} <: JSONContext),
 quote
     io::T
     first::Bool
@@ -103,7 +103,7 @@ For compact printing, which in JSON is fully recursive.
 """ CompactContext
 CompactContext(io::IO) = CompactContext(io, false)
 
-eval(Expr(:type, false, :(StringContext{T<:IO} <: IO),
+eval(Expr(Common.STRUCTHEAD, false, :(StringContext{T<:IO} <: IO),
 quote
     io::T
 end))

--- a/test/json-checker.jl
+++ b/test/json-checker.jl
@@ -23,6 +23,6 @@ for i in 1:27
     file = "roundtrip$(lpad(i, 2, 0)).json"
     filepath = joinpath(JSON_DATA_DIR, "roundtrip", file)
 
-    rt = roundtrip(readstring(filepath))
+    rt = roundtrip(read(filepath, String))
     @test rt == roundtrip(rt)
 end

--- a/test/json-samples.jl
+++ b/test/json-samples.jl
@@ -298,7 +298,7 @@ colors3 = "{
 
 twitter = "{\"results\":[
 
-     {\"text\":\"@twitterapi  http:\/\/tinyurl.com\/ctrefg\",
+     {\"text\":\"@twitterapi  http://tinyurl.com/ctrefg\",
      \"to_user_id\":396524,
      \"to_user\":\"TwitterAPI\",
      \"from_user\":\"jkoum\",
@@ -310,8 +310,8 @@ twitter = "{\"results\":[
      \"id\":1478555574,
      \"from_user_id\":1833773,
      \"iso_language_code\":\"nl\",
-     \"source\":\"<a href=\\\"http:\/\/twitter.com\/\\\">twitter<\/a>\",
-     \"profile_image_url\":\"http:\/\/s3.amazonaws.com\/twitter_production\/profile_images\/118412707\/2522215727_a5f07da155_b_normal.jpg\",
+     \"source\":\"<a href=\\\"http://twitter.com/\\\">twitter</a>\",
+     \"profile_image_url\":\"http://s3.amazonaws.com/twitter_production/profile_images/118412707/2522215727_a5f07da155_b_normal.jpg\",
      \"created_at\":\"Wed, 08 Apr 2009 19:22:10 +0000\"}],
      \"since_id\":0,
      \"max_id\":1480307926,
@@ -380,7 +380,7 @@ const flickr = """{
             "link": "http://www.flickr.com/photos/33112458@N08/3081564649/in/pool-998875@N22",
             "media": {"m":"http://farm4.static.flickr.com/3037/3081564649_4a6569750c_m.jpg"},
             "date_taken": "2008-12-04T04:43:03-08:00",
-            "description": "<p><a href=\\"http://www.flickr.com/people/33112458@N08/\\"> Talk On Travel<\/a> has added a photo to the pool:<\/p> <p><a href=\\"http:// www.flickr.com/photos/33112458@N08/3081564649/\\" title=\\"View from the hotel\\"> <img src=\\"http://farm4.static.flickr.com/3037/3081564649_4a6569750c_m.jpg\\" width=\\"240\\" height=\\"180\\" alt=\\"View from the hotel\\" /><\/a><\/p> ",
+            "description": "<p><a href=\\"http://www.flickr.com/people/33112458@N08/\\"> Talk On Travel</a> has added a photo to the pool:</p> <p><a href=\\"http:// www.flickr.com/photos/33112458@N08/3081564649/\\" title=\\"View from the hotel\\"> <img src=\\"http://farm4.static.flickr.com/3037/3081564649_4a6569750c_m.jpg\\" width=\\"240\\" height=\\"180\\" alt=\\"View from the hotel\\" /></a></p> ",
             "published": "2008-12-04T12:43:03Z",
             "author": "nobody@flickr.com (Talk On Travel)",
             "author_id": "33112458@N08",
@@ -593,15 +593,15 @@ interop = "{
             {
                 \"Title\": \"potato jpg\",
                 \"Summary\": \"Kentang Si bungsu dari keluarga Solanum tuberosum L ini ternyata memiliki khasiat untuk mengurangi kerutan  jerawat  bintik hitam dan kemerahan pada kulit  Gunakan seminggu sekali sebagai\",
-                \"Url\": \"http:\/\/www.mediaindonesia.com\/spaw\/uploads\/images\/potato.jpg\",
-                \"ClickUrl\": \"http:\/\/www.mediaindonesia.com\/spaw\/uploads\/images\/potato.jpg\",
-                \"RefererUrl\": \"http:\/\/www.mediaindonesia.com\/mediaperempuan\/index.php?ar_id=Nzkw\",
+                \"Url\": \"http://www.mediaindonesia.com/spaw/uploads/images/potato.jpg\",
+                \"ClickUrl\": \"http://www.mediaindonesia.com/spaw/uploads/images/potato.jpg\",
+                \"RefererUrl\": \"http://www.mediaindonesia.com/mediaperempuan/index.php?ar_id=Nzkw\",
                 \"FileSize\": 22630,
                 \"FileFormat\": \"jpeg\",
                 \"Height\": \"362\",
                 \"Width\": \"532\",
                 \"Thumbnail\": {
-                    \"Url\": \"http:\/\/thm-a01.yimg.com\/nimage\/557094559c18f16a\",
+                    \"Url\": \"http://thm-a01.yimg.com/nimage/557094559c18f16a\",
                     \"Height\": \"98\",
                     \"Width\": \"145\"
                 }
@@ -609,15 +609,15 @@ interop = "{
             {
                 \"Title\": \"potato jpg\",
                 \"Summary\": \"Introduction of puneri aloo This is a traditional potato preparation flavoured with curry leaves and peanuts and can be eaten on fasting day  Preparation time   10 min\",
-                \"Url\": \"http:\/\/www.infovisual.info\/01\/photo\/potato.jpg\",
-                \"ClickUrl\": \"http:\/\/www.infovisual.info\/01\/photo\/potato.jpg\",
-                \"RefererUrl\": \"http:\/\/sundayfood.com\/puneri-aloo-indian-%20recipe\",
+                \"Url\": \"http://www.infovisual.info/01/photo/potato.jpg\",
+                \"ClickUrl\": \"http://www.infovisual.info/01/photo/potato.jpg\",
+                \"RefererUrl\": \"http://sundayfood.com/puneri-aloo-indian-%20recipe\",
                 \"FileSize\": 119398,
                 \"FileFormat\": \"jpeg\",
                 \"Height\": \"685\",
                 \"Width\": \"1024\",
                 \"Thumbnail\": {
-                    \"Url\": \"http:\/\/thm-a01.yimg.com\/nimage\/7fa23212efe84b64\",
+                    \"Url\": \"http://thm-a01.yimg.com/nimage/7fa23212efe84b64\",
                     \"Height\": \"107\",
                     \"Width\": \"160\"
                 }

--- a/test/lowering.jl
+++ b/test/lowering.jl
@@ -12,7 +12,7 @@ end
 @test JSON.json(:x) == "\"x\""
 @test_throws ArgumentError JSON.json(Base)
 
-eval(Expr(:type, false, :(Type151{T}), quote
+eval(Expr(JSON.Common.STRUCTHEAD, false, :(Type151{T}), quote
     x::T
 end))
 

--- a/test/parser/parsefile.jl
+++ b/test/parser/parsefile.jl
@@ -1,7 +1,7 @@
 tmppath, io = mktemp()
 write(io, facebook)
 close(io)
-if is_windows()
+if Compat.Sys.iswindows()
     # don't use mmap on Windows, to avoid ERROR: unlink: operation not permitted (EPERM)
     @test haskey(JSON.parsefile(tmppath; use_mmap=false), "data")
 else

--- a/test/regression/issue109.jl
+++ b/test/regression/issue109.jl
@@ -1,4 +1,4 @@
-eval(Expr(:type, true, :t109,
+eval(Expr(JSON.Common.STRUCTHEAD, true, :t109,
 quote
     i::Int
 end))

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -20,7 +20,7 @@ function sprint_kwarg(f, args...; kwargs...)
 end
 
 # issue #168: Print NaN and Inf as Julia would
-eval(Expr(:type, false, :(NaNSerialization <: CS), quote end))
+eval(Expr(JSON.Common.STRUCTHEAD, false, :(NaNSerialization <: CS), quote end))
 JSON.show_json(io::SC, ::NaNSerialization, f::AbstractFloat) =
     Base.print(io, f)
 
@@ -42,8 +42,8 @@ JSON.show_json(io::SC, ::NaNSerialization, f::AbstractFloat) =
 """
 
 # issue #170: Print JavaScript functions directly
-eval(Expr(:type, false, :(JSSerialization <: CS), quote end))
-eval(Expr(:type, false, :JSFunction,
+eval(Expr(JSON.Common.STRUCTHEAD, false, :(JSSerialization <: CS), quote end))
+eval(Expr(JSON.Common.STRUCTHEAD, false, :JSFunction,
 quote
     data::String
 end))
@@ -74,7 +74,7 @@ end
 """
 
 # test serializing a type without any fields
-eval(Expr(:type, false, :SingletonType, quote end))
+eval(Expr(JSON.Common.STRUCTHEAD, false, :SingletonType, quote end))
 @test_throws ErrorException json(SingletonType())
 
 # test printing to STDOUT

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -84,7 +84,7 @@ let filename = tempname()
             JSON.print(Any[1, 2, 3.0])
         end
     end
-    @test readstring(filename) == "[1,2,3.0]"
+    @test read(filename, String) == "[1,2,3.0]"
     rm(filename)
 end
 


### PR DESCRIPTION
Fixes the test failure on nightly, and more deprecations. Some deprecations can't be easily fixed right now.