### PR TITLE
Drop v0.5 support, Compat dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
     - osx
     - linux
 julia:
-    - 0.5
     - 0.6
     - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5
-Compat 0.31.0
+julia 0.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/Common.jl
+++ b/src/Common.jl
@@ -3,12 +3,6 @@ Internal implementation detail.
 """
 module Common
 
-using Compat
-
-# The expression head to use for constructing types.
-# TODO: Remove this hack when 0.5 support is dropped.
-const STRUCTHEAD = VERSION < v"0.7.0-DEV.1263" ? :type : :struct
-
 include("bytes.jl")
 include("errors.jl")
 

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -2,8 +2,6 @@ __precompile__()
 
 module JSON
 
-using Compat
-
 export json # returns a compact (or indented) JSON representation as a string
 
 include("Common.jl")

--- a/src/Serializations.jl
+++ b/src/Serializations.jl
@@ -7,27 +7,24 @@ implementations, as they relate to JSON.
 
 module Serializations
 
-using Compat
 using ..Common
 
 """
 A `Serialization` defines how objects are lowered to JSON format.
 """
-@compat abstract type Serialization end
+abstract type Serialization end
 
-@compat abstract type CommonSerialization <: Serialization end
-@doc """
+"""
 The `CommonSerialization` comes with a default set of rules for serializing
 Julia types to their JSON equivalents. Additional rules are provided either by
 packages explicitly defining `JSON.show_json` for this serialization, or by the
 `JSON.lower` method. Most concrete implementations of serializers should subtype
 `CommonSerialization`, unless it is desirable to bypass the `lower` system, in
 which case `Serialization` should be subtyped.
-""" CommonSerialization
+"""
+abstract type CommonSerialization <: Serialization end
 
-eval(Expr(Common.STRUCTHEAD, false, :(StandardSerialization <: CommonSerialization),
-          quote end))
-@doc """
+"""
 The `StandardSerialization` defines a common, standard JSON serialization format
 that is optimized to:
 
@@ -37,6 +34,7 @@ that is optimized to:
 All serializations defined for `CommonSerialization` are inherited by
 `StandardSerialization`. It is therefore generally advised to add new
 serialization behaviour to `CommonSerialization`.
-""" StandardSerialization
+"""
+struct StandardSerialization <: CommonSerialization end
 
 end

--- a/src/bytes.jl
+++ b/src/bytes.jl
@@ -52,7 +52,7 @@ for c in 0x00:0xFF
         [c]  # UTF-8 character copied verbatim
     elseif haskey(REVERSE_ESCAPES, c)
         [BACKSLASH, REVERSE_ESCAPES[c]]
-    elseif iscntrl(@compat Char(c)) || !isprint(@compat Char(c))
+    elseif iscntrl(Char(c)) || !isprint(Char(c))
         UInt8[BACKSLASH, LATIN_U, hex(c, 4)...]
     else
         [c]

--- a/src/specialized.jl
+++ b/src/specialized.jl
@@ -1,13 +1,11 @@
 # Specialized functions for increased performance when JSON is in-memory
-using Compat: StringVector
-
 function parse_string(ps::MemoryParserState)
     # "Dry Run": find length of string so we can allocate the right amount of
     # memory from the start. Does not do full error checking.
     fastpath, len = predict_string(ps)
 
     # Now read the string itself
-    b = StringVector(len)
+    b = Base.StringVector(len)
 
     # Fast path occurs when the string has no escaped characters. This is quite
     # often the case in real-world data, especially when keys are short strings.

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,4 @@
 DataStructures
 FixedPointNumbers
 OffsetArrays
+Compat 0.31.0

--- a/test/lowering.jl
+++ b/test/lowering.jl
@@ -2,7 +2,6 @@ module TestLowering
 
 using JSON
 using Base.Test
-using Compat
 using FixedPointNumbers: Fixed
 
 if isdefined(Base, :Dates)
@@ -12,13 +11,13 @@ end
 @test JSON.json(:x) == "\"x\""
 @test_throws ArgumentError JSON.json(Base)
 
-eval(Expr(JSON.Common.STRUCTHEAD, false, :(Type151{T}), quote
+struct Type151{T}
     x::T
-end))
+end
 
 @test JSON.parse(JSON.json(Type151)) == string(Type151)
 
-JSON.lower{T}(v::Type151{T}) = Dict(:type => T, :value => v.x)
+JSON.lower(v::Type151{T}) where {T} = Dict(:type => T, :value => v.x)
 @test JSON.parse(JSON.json(Type151(1.0))) == Dict(
     "type" => "Float64",
     "value" => 1.0)

--- a/test/regression/issue109.jl
+++ b/test/regression/issue109.jl
@@ -1,7 +1,6 @@
-eval(Expr(JSON.Common.STRUCTHEAD, true, :t109,
-quote
+mutable struct t109
     i::Int
-end))
+end
 
 let iob = IOBuffer()
     JSON.print(iob, t109(1))

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -2,7 +2,6 @@ module TestSerializer
 
 using JSON
 using Base.Test
-using Compat
 
 # to define a new serialization behaviour, import these first
 import JSON.Serializations: CommonSerialization, StandardSerialization
@@ -20,9 +19,8 @@ function sprint_kwarg(f, args...; kwargs...)
 end
 
 # issue #168: Print NaN and Inf as Julia would
-eval(Expr(JSON.Common.STRUCTHEAD, false, :(NaNSerialization <: CS), quote end))
-JSON.show_json(io::SC, ::NaNSerialization, f::AbstractFloat) =
-    Base.print(io, f)
+struct NaNSerialization <: CS end
+JSON.show_json(io::SC, ::NaNSerialization, f::AbstractFloat) = Base.print(io, f)
 
 @test sprint(JSON.show_json, NaNSerialization(), [NaN, Inf, -Inf, 0.0]) ==
     "[NaN,Inf,-Inf,0.0]"
@@ -42,11 +40,10 @@ JSON.show_json(io::SC, ::NaNSerialization, f::AbstractFloat) =
 """
 
 # issue #170: Print JavaScript functions directly
-eval(Expr(JSON.Common.STRUCTHEAD, false, :(JSSerialization <: CS), quote end))
-eval(Expr(JSON.Common.STRUCTHEAD, false, :JSFunction,
-quote
+struct JSSerialization <: CS end
+struct JSFunction
     data::String
-end))
+end
 
 function JSON.show_json(io::SC, ::JSSerialization, f::JSFunction)
     first = true
@@ -74,7 +71,7 @@ end
 """
 
 # test serializing a type without any fields
-eval(Expr(JSON.Common.STRUCTHEAD, false, :SingletonType, quote end))
+struct SingletonType end
 @test_throws ErrorException json(SingletonType())
 
 # test printing to STDOUT


### PR DESCRIPTION
This drops the 0.5 support for JSON, and along with it several hacks and Compats we've been using. Compat is still needed for tests. Also has the effect of fixing all the deprecations on master.

Will merge and tag in a few days if there are no objections.