### PR TITLE
Restore 100% test coverage

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -250,13 +250,6 @@ function show_json(io::SC, s::CS, x::IsPrintedAsString)
 end
 
 function show_json(io::SC, s::CS, x::Union{Integer, AbstractFloat})
-    # workaround for issue in Julia 0.5.x where Float32 values are printed as
-    # 3.4f-5 instead of 3.4e-5
-    @static if VERSION < v"0.6.0-dev.788"
-        if isa(x, Float32)
-            return show_json(io, s, Float64(x))
-        end
-    end
     if isfinite(x)
         Base.print(io, x)
     else

--- a/test/parser/invalid-input.jl
+++ b/test/parser/invalid-input.jl
@@ -5,6 +5,7 @@ const FAILURES = [
     "{\"1\":2, \"2\":3 _ \"4\":5}",
     # Invalid escaped character
     "[\"alpha\\α\"]",
+    "[\"\\u05AG\"]",
     # Invalid 'simple' and 'unknown value'
     "[tXXe]",
     "[fail]",


### PR DESCRIPTION
Remove an obsolete branch and add an expected error case for invalid input, to get back to 100% test coverage.