### PR TITLE
Revert Compat dependency removal

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat 0.30.0

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -1,5 +1,6 @@
 module Parser  # JSON
 
+using Compat
 using ..Common
 
 """


### PR DESCRIPTION
cc @tkelman 

Sorry for the oversight. This partially reverts the removal of the Compat dependency in 0.15.0. Should be tagged as 0.15.1 when merged.

(as an aside: for these reasons, I suppose it's best for tests to avoid importing Compat when the main library doesn't, to avoid these situations being missed.)