### PR TITLE
Allow user to specify integer parsing type (fixes #223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ json(a::Any)
 Returns a compact JSON representation as an `AbstractString`.
 
 ```julia
-JSON.parse(s::AbstractString; dicttype=Dict)
-JSON.parse(io::IO; dicttype=Dict)
-JSON.parsefile(filename::AbstractString; dicttype=Dict, use_mmap=true)
+JSON.parse(s::AbstractString; dicttype=Dict, inttype=Int64)
+JSON.parse(io::IO; dicttype=Dict, inttype=Int64)
+JSON.parsefile(filename::AbstractString; dicttype=Dict, inttype=Int64, use_mmap=true)
 ```
 
 Parses a JSON `AbstractString` or IO stream into a nested `Array` or `Dict`.
@@ -69,6 +69,14 @@ provide a desired ordering.  For example, if you `import DataStructures`
 package](https://github.com/JuliaLang/DataStructures.jl) is
 installed), you can pass `dicttype=DataStructures.OrderedDict` to
 maintain the insertion order of the items in the object.
+
+The `inttype` argument controls how integers are parsed.  If a number in a JSON
+file is recognized to be an integer, it is parsed as one; otherwise it is parsed 
+as a `Float64`.  The `inttype` defaults to `Int64`, but, for example, if you know
+that your integer numbers are all small and want to save space, you can pass 
+`inttype=Int32`.  Alternatively, if your JSON input has integers which are too large
+for Int64, you can pass `inttype=Int128` or `inttype=BigInt`.  `inttype` can be any
+subtype of `Real`.
 
 ```julia
 JSON.lower(p::Point2D) = [p.x, p.y]

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -201,7 +201,7 @@ end
 
 function parse_object(ps::ParserState, pc::ParserContext{DictType, <:Real}) where DictType
     obj = DictType()
-    keyT = DictType.parameters[1]
+    keyT = keytype(DictType)
 
     incr!(ps)  # Skip over opening '{'
     chomp_space!(ps)

--- a/test/parser/inttype.jl
+++ b/test/parser/inttype.jl
@@ -1,0 +1,16 @@
+@testset for T in [Int32, Int64, Int128]
+  val = JSON.parse("{\"x\": 3}", inttype=T)
+  @test isa(val, Dict{String, Any})
+  @test length(val) == 1
+  key = collect(keys(val))[1]
+  @test string(key) == "x"
+  value = val[key]
+  @test value == 3
+  @test typeof(value) == T
+end
+
+@testset begin
+  teststr = """{"201736327611975630": 18005722827070440994}"""
+  val = JSON.parse(teststr, inttype=Int128)
+  @test val == Dict{String,Any}("201736327611975630"=> 18005722827070440994)
+end

--- a/test/parser/inttype.jl
+++ b/test/parser/inttype.jl
@@ -1,4 +1,4 @@
-@testset for T in [Int32, Int64, Int128]
+@testset for T in [Int32, Int64, Int128, BigInt]
     val = JSON.parse("{\"x\": 3}", inttype=T)
     @test isa(val, Dict{String, Any})
     @test length(val) == 1

--- a/test/parser/inttype.jl
+++ b/test/parser/inttype.jl
@@ -1,16 +1,16 @@
 @testset for T in [Int32, Int64, Int128]
-  val = JSON.parse("{\"x\": 3}", inttype=T)
-  @test isa(val, Dict{String, Any})
-  @test length(val) == 1
-  key = collect(keys(val))[1]
-  @test string(key) == "x"
-  value = val[key]
-  @test value == 3
-  @test typeof(value) == T
+    val = JSON.parse("{\"x\": 3}", inttype=T)
+    @test isa(val, Dict{String, Any})
+    @test length(val) == 1
+    key = collect(keys(val))[1]
+    @test string(key) == "x"
+    value = val[key]
+    @test value == 3
+    @test typeof(value) == T
 end
 
 @testset begin
-  teststr = """{"201736327611975630": 18005722827070440994}"""
-  val = JSON.parse(teststr, inttype=Int128)
-  @test val == Dict{String,Any}("201736327611975630"=> 18005722827070440994)
+    teststr = """{"201736327611975630": 18005722827070440994}"""
+    val = JSON.parse(teststr, inttype=Int128)
+    @test val == Dict{String,Any}("201736327611975630"=> 18005722827070440994)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,10 @@ include("json-samples.jl")
         include("parser/dicttype.jl")
     end
 
+    @testset "inttype" begin
+        include("parser/inttype.jl")
+    end
+
     @testset "Miscellaneous" begin
         # test for single values
         @test JSON.parse("true") == true


### PR DESCRIPTION
* Added a ParserContext object, containing the `DictType` and `IntType` to use for parsing JSON

This is a minimally invasive way of giving the user more control over parsing.  

A possible extension would be to allow specifying the float format to parse (e.g., `DecFP`, `Decimals`, `FixedPointNumbers`, etc.), although this would probably require a bit more work.

**Edit:** Addresses part of #223, although it does not implement overflow checking.