### PR TITLE
reduce number of string/buffer allocations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.45.0
+Compat 0.51.0
 Nullables 0.0.1

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -136,7 +136,7 @@ function _error(message::AbstractString, ps::MemoryParserState)
     # Replace all special multi-line/multi-space characters with a space.
     strnl = replace(orig, r"[\b\f\n\r\t\s]" => " ")
     li = (ps.s > 20) ? ps.s - 9 : 1 # Left index
-    ri = min(sizeof(orig), ps.s + 20)       # Right index
+    ri = min(lastindex(orig), ps.s + 20)       # Right index
     error(message *
       "\nLine: " * string(lines) *
       "\nAround: ..." * strnl[li:ri] * "..." *

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -20,9 +20,14 @@ isjsondigit(b::UInt8) = DIGIT_ZERO ≤ b ≤ DIGIT_NINE
 abstract type ParserState end
 
 mutable struct MemoryParserState <: ParserState
-    utf8data::Vector{UInt8}
+    utf8::String
     s::Int
 end
+
+# it is convenient to access MemoryParserState like a Vector{UInt8} to avoid copies
+Base.@propagate_inbounds Base.getindex(state::MemoryParserState, i::Int) = codeunit(state.utf8, i)
+Base.length(state::MemoryParserState) = sizeof(state.utf8)
+Base.unsafe_convert(::Type{Ptr{UInt8}}, state::MemoryParserState) = unsafe_convert(Ptr{UInt8}, state.utf8)
 
 mutable struct StreamingParserState{T <: IO} <: ParserState
     io::T
@@ -40,7 +45,7 @@ input ended unexpectedly.
 """
 @inline function byteat(ps::MemoryParserState)
     @inbounds if hasmore(ps)
-        return ps.utf8data[ps.s]
+        return ps[ps.s]
     else
         _error(E_UNEXPECTED_EOF, ps)
     end
@@ -62,7 +67,7 @@ end
 Like `byteat`, but with no special bounds check and error message. Useful when
 a current byte is known to exist.
 """
-@inline current(ps::MemoryParserState) = ps.utf8data[ps.s]
+@inline current(ps::MemoryParserState) = ps[ps.s]
 @inline current(ps::StreamingParserState) = byteat(ps)
 
 """
@@ -99,7 +104,7 @@ the advancement. If the `ParserState` is already done, then throw an error.
 Return `true` if there is a current byte, and `false` if all bytes have been
 exausted.
 """
-@inline hasmore(ps::MemoryParserState) = ps.s ≤ endof(ps.utf8data)
+@inline hasmore(ps::MemoryParserState) = ps.s ≤ length(ps)
 @inline hasmore(ps::StreamingParserState) = true  # no more now ≠ no more ever
 
 """
@@ -126,12 +131,12 @@ end
 
 # Throws an error message with an indicator to the source
 function _error(message::AbstractString, ps::MemoryParserState)
-    orig = String(ps.utf8data)
+    orig = ps.utf8
     lines = _count_before(orig, '\n', ps.s)
     # Replace all special multi-line/multi-space characters with a space.
     strnl = replace(orig, r"[\b\f\n\r\t\s]" => " ")
     li = (ps.s > 20) ? ps.s - 9 : 1 # Left index
-    ri = min(endof(orig), ps.s + 20)       # Right index
+    ri = min(sizeof(orig), ps.s + 20)       # Right index
     error(message *
       "\nLine: " * string(lines) *
       "\nAround: ..." * strnl[li:ri] * "..." *
@@ -262,10 +267,8 @@ function read_unicode_escape!(ps)
     end
 end
 
-get_bytes(str) = Vector{UInt8}(@static isdefined(Base, :codeunits) ? codeunits(str) : str)
-
 function parse_string(ps::ParserState)
-    b = UInt8[]
+    b = IOBuffer()
     incr!(ps)  # skip opening quote
     while true
         c = advance!(ps)
@@ -273,20 +276,20 @@ function parse_string(ps::ParserState)
         if c == BACKSLASH
             c = advance!(ps)
             if c == LATIN_U  # Unicode escape
-                append!(b, get_bytes(string(read_unicode_escape!(ps))))
+                write(b, read_unicode_escape!(ps))
             else
                 c = get(ESCAPES, c, 0x00)
                 c == 0x00 && _error(E_BAD_ESCAPE, ps)
-                push!(b, c)
+                write(b, c)
             end
             continue
         elseif c < SPACE
             _error(E_BAD_CONTROL, ps)
         elseif c == STRING_DELIM
-            return String(b)
+            return String(take!(b))
         end
 
-        push!(b, c)
+        write(b, c)
     end
 end
 
@@ -294,7 +297,7 @@ end
 Return `true` if the given bytes vector, starting at `from` and ending at `to`,
 has a leading zero.
 """
-function hasleadingzero(bytes::Vector{UInt8}, from::Int, to::Int)
+function hasleadingzero(bytes, from::Int, to::Int)
     c = bytes[from]
     from + 1 < to && c == UInt8('-') &&
             bytes[from + 1] == DIGIT_ZERO && isjsondigit(bytes[from + 2]) ||
@@ -306,7 +309,7 @@ end
 Parse a float from the given bytes vector, starting at `from` and ending at the
 byte before `to`. Bytes enclosed should all be ASCII characters.
 """
-function float_from_bytes(bytes::Vector{UInt8}, from::Int, to::Int)
+function float_from_bytes(bytes, from::Int, to::Int)
     # The ccall is not ideal (Base.tryparse would be better), but it actually
     # makes an 2× difference to performance
     ccall(:jl_try_substrtod, Nullable{Float64},
@@ -317,10 +320,10 @@ end
 Parse an integer from the given bytes vector, starting at `from` and ending at
 the byte before `to`. Bytes enclosed should all be ASCII characters.
 """
-function int_from_bytes(pc::ParserContext{<:AbstractDict,IntType}, 
-                        ps::ParserState, 
-                        bytes::Vector{UInt8}, 
-                        from::Int, 
+function int_from_bytes(pc::ParserContext{<:AbstractDict,IntType},
+                        ps::ParserState,
+                        bytes,
+                        from::Int,
                         to::Int) where IntType <: Real
     @inbounds isnegative = bytes[from] == MINUS_SIGN ? (from += 1; true) : false
     num = IntType(0)
@@ -330,11 +333,11 @@ function int_from_bytes(pc::ParserContext{<:AbstractDict,IntType},
     ifelse(isnegative, -num, num)
 end
 
-function number_from_bytes(pc::ParserContext, 
-                           ps::ParserState, 
-                           isint::Bool, 
-                           bytes::Vector{UInt8}, 
-                           from::Int, 
+function number_from_bytes(pc::ParserContext,
+                           ps::ParserState,
+                           isint::Bool,
+                           bytes,
+                           from::Int,
                            to::Int)
     @inbounds if hasleadingzero(bytes, from, to)
         _error(E_LEADING_ZERO, ps)
@@ -386,7 +389,7 @@ function parse(str::AbstractString;
                dicttype::Type{<:AbstractDict}=Dict{String,Any},
                inttype::Type{<:Real}=Int64)
     pc = ParserContext{unparameterize_type(dicttype), inttype}()
-    ps = MemoryParserState(get_bytes(str), 1)
+    ps = MemoryParserState(str, 1)
     v = parse_value(pc, ps)
     chomp_space!(ps)
     if hasmore(ps)

--- a/src/specialized.jl
+++ b/src/specialized.jl
@@ -18,7 +18,6 @@ function parse_string(ps::MemoryParserState)
     else
         String(take!(parse_string(ps, IOBuffer(len))))
     end
-
 end
 
 """

--- a/src/specialized.jl
+++ b/src/specialized.jl
@@ -11,8 +11,10 @@ function parse_string(ps::MemoryParserState)
     # We can just copy the data from the buffer in this case.
     if fastpath
         s = ps.s
-        ps.s = s + len + 2
-        return ps.utf8[s+1:s+len] # slicing a String returns a String
+        e = s + len
+        ps.s = e + 2 # byte after closing quote
+        while !isvalid(ps.utf8,e) & (e > s); e -= 1; end # find last char index
+        return ps.utf8[s+1:e] # slicing a String returns a String
     else
         String(take!(parse_string(ps, IOBuffer(len))))
     end

--- a/src/specialized.jl
+++ b/src/specialized.jl
@@ -11,10 +11,8 @@ function parse_string(ps::MemoryParserState)
     # We can just copy the data from the buffer in this case.
     if fastpath
         s = ps.s
-        e = s + len
-        ps.s = e + 2 # byte after closing quote
-        while !isvalid(ps.utf8,e) & (e > s); e -= 1; end # find last char index
-        return ps.utf8[s+1:e] # slicing a String returns a String
+        ps.s = s + len + 2 # byte after closing quote
+        return unsafe_string(pointer(ps.utf8)+s, len)
     else
         String(take!(parse_string(ps, IOBuffer(len))))
     end

--- a/src/specialized.jl
+++ b/src/specialized.jl
@@ -4,21 +4,19 @@ function parse_string(ps::MemoryParserState)
     # memory from the start. Does not do full error checking.
     fastpath, len = predict_string(ps)
 
-    # Now read the string itself
-    b = Base.StringVector(len)
+    # Now read the string itself:
 
     # Fast path occurs when the string has no escaped characters. This is quite
     # often the case in real-world data, especially when keys are short strings.
     # We can just copy the data from the buffer in this case.
     if fastpath
         s = ps.s
-        unsafe_copyto!(b, 1, ps.utf8data, s + 1, len)
         ps.s = s + len + 2
+        return ps.utf8[s+1:s+len] # slicing a String returns a String
     else
-        parse_string(ps, b)
+        String(take!(parse_string(ps, IOBuffer(len))))
     end
 
-    String(b)
 end
 
 """
@@ -44,20 +42,20 @@ This function will throw an error if:
 No error is thrown when other invalid backslash escapes are encountered.
 """
 function predict_string(ps::MemoryParserState)
-    e = endof(ps.utf8data)
+    e = length(ps)
     fastpath = true  # true if no escapes in this string, so it can be copied
     len = 0          # the number of UTF8 bytes the string contains
 
     s = ps.s + 1     # skip past opening string character "
     @inbounds while s <= e
-        c = ps.utf8data[s]
+        c = ps[s]
         if c == BACKSLASH
             fastpath = false
             (s += 1) > e && break
-            if ps.utf8data[s] == LATIN_U  # Unicode escape
+            if ps[s] == LATIN_U  # Unicode escape
                 t = ps.s
                 ps.s = s + 1
-                len += sizeof(string(read_unicode_escape!(ps)))
+                len += write(DevNull, read_unicode_escape!(ps))
                 s = ps.s
                 ps.s = t
                 continue
@@ -78,28 +76,24 @@ end
 
 """
 Parse the string starting at the parser state’s current location into the given
-pre-sized buffer. The only correctness checking is for escape sequences, so the
+pre-sized IOBuffer. The only correctness checking is for escape sequences, so the
 passed-in buffer must exactly represent the amount of space needed for parsing.
 """
-function parse_string(ps::MemoryParserState, b)
+function parse_string(ps::MemoryParserState, b::IOBuffer)
     s = ps.s
-    e = endof(ps.utf8data)
-    i = 0  # number of characters copied
+    e = length(ps)
 
     s += 1  # skip past opening string character "
-    len = length(b)
-    @inbounds while i < len
-        c = ps.utf8data[s]
+    len = b.maxsize
+    @inbounds while b.size < len
+        c = ps[s]
         if c == BACKSLASH
             s += 1
             s > e && break
-            c = ps.utf8data[s]
+            c = ps[s]
             if c == LATIN_U  # Unicode escape
                 ps.s = s + 1
-                for c2 in get_bytes(string(read_unicode_escape!(ps)))
-                    i += 1
-                    b[i] = c2
-                end
+                write(b, read_unicode_escape!(ps))
                 s = ps.s
                 continue
             else
@@ -113,8 +107,7 @@ function parse_string(ps::MemoryParserState, b)
 
         # UTF8-encoded non-ascii characters will be copied verbatim, which is
         # the desired behaviour
-        i += 1
-        b[i] = c
+        write(b, c)
         s += 1
     end
 
@@ -126,13 +119,13 @@ end
 
 function parse_number(ps::MemoryParserState)
     s = p = ps.s
-    e = endof(ps.utf8data)
+    e = length(ps)
     isint = true
 
     # Determine the end of the floating point by skipping past ASCII values
     # 0-9, +, -, e, E, and .
     while p ≤ e
-        @inbounds c = ps.utf8data[p]
+        @inbounds c = ps[p]
         if isjsondigit(c) || MINUS_SIGN == c  # no-op
         elseif PLUS_SIGN == c || LATIN_E == c || LATIN_UPPER_E == c ||
                 DECIMAL_POINT == c
@@ -144,5 +137,5 @@ function parse_number(ps::MemoryParserState)
     end
     ps.s = p
 
-    number_from_bytes(ps, isint, ps.utf8data, s, p - 1)
+    number_from_bytes(ps, isint, ps, s, p - 1)
 end


### PR DESCRIPTION
This eliminates a number of unnecessary string and buffer allocations.   It eliminates those from #234, and also eliminates several associated with Unicode escapes: rather than converting a `Char` to a `String` to get the UTF-8 representation, I write it directly to a buffer.

Most of the changes are deleting/simplifying code: my favorite kind of optimization :wink:.