### PR TITLE
JSONText(string) for embedding raw JSON in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,18 @@ installed), you can pass `dicttype=DataStructures.OrderedDict` to
 maintain the insertion order of the items in the object.
 
 The `inttype` argument controls how integers are parsed.  If a number in a JSON
-file is recognized to be an integer, it is parsed as one; otherwise it is parsed 
+file is recognized to be an integer, it is parsed as one; otherwise it is parsed
 as a `Float64`.  The `inttype` defaults to `Int64`, but, for example, if you know
-that your integer numbers are all small and want to save space, you can pass 
+that your integer numbers are all small and want to save space, you can pass
 `inttype=Int32`.  Alternatively, if your JSON input has integers which are too large
 for Int64, you can pass `inttype=Int128` or `inttype=BigInt`.  `inttype` can be any
 subtype of `Real`.
+
+```julia
+JSONText(s::AbstractString)
+```
+A wrapper around a Julia string representing JSON-formatted text,
+which is inserted *as-is* in the JSON output of `JSON.print` and `JSON.json`.
 
 ```julia
 JSON.lower(p::Point2D) = [p.x, p.y]

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -3,6 +3,7 @@ __precompile__()
 module JSON
 
 export json # returns a compact (or indented) JSON representation as a string
+export JSONText # string wrapper to insert raw JSON into JSON output
 
 include("Common.jl")
 
@@ -19,7 +20,8 @@ include("Writer.jl")
 using .Parser: parse, parsefile
 using .Writer: show_json, json, lower, print, StructuralContext, show_element,
                show_string, show_key, show_pair, show_null, begin_array,
-               end_array, begin_object, end_object, indent, delimit, separate
+               end_array, begin_object, end_object, indent, delimit, separate,
+               JSONText
 using .Serializations: Serialization, CommonSerialization,
                        StandardSerialization
 

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -25,4 +25,7 @@ using .Writer: show_json, json, lower, print, StructuralContext, show_element,
 using .Serializations: Serialization, CommonSerialization,
                        StandardSerialization
 
+# for pretty-printed (non-compact) output, JSONText must be re-parsed:
+Writer.lower(json::JSONText) = parse(json.s)
+
 end # module

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -338,6 +338,19 @@ function show_json(io::IO, s::Serialization, obj; indent=nothing)
     end
 end
 
+"""
+    JSONText(s::AbstractString)
+
+`JSONText` is a wrapper around a Julia string representing JSON-formatted
+text, which is inserted *as-is* in the JSON output of `JSON.print` and `JSON.json`.
+(If `s` does *not* contain valid JSON-formatted text, this will make the
+JSON output malformed.)
+"""
+struct JSONText
+    s::String
+end
+show_json(io::SC, s::CS, json::JSONText) = write(io, json.s)
+
 print(io::IO, obj, indent) =
     show_json(io, StandardSerialization(), obj; indent=indent)
 print(io::IO, obj) = show_json(io, StandardSerialization(), obj)

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -342,14 +342,17 @@ end
     JSONText(s::AbstractString)
 
 `JSONText` is a wrapper around a Julia string representing JSON-formatted
-text, which is inserted *as-is* in the JSON output of `JSON.print` and `JSON.json`.
-(If `s` does *not* contain valid JSON-formatted text, this will make the
-JSON output malformed.)
+text, which is inserted *as-is* in the JSON output of `JSON.print` and `JSON.json`
+for compact output, and is otherwise re-parsed for pretty-printed output.
+
+`s` *must* contain valid JSON text.  Otherwise compact output will contain
+the malformed `s` and other serialization output will throw a parsing exception.
 """
 struct JSONText
     s::String
 end
-show_json(io::SC, s::CS, json::JSONText) = write(io, json.s)
+show_json(io::CompactContext, s::CS, json::JSONText) = write(io, json.s)
+# other contexts for JSONText are handled by lower(json) = parse(json.s)
 
 print(io::IO, obj, indent) =
     show_json(io, StandardSerialization(), obj; indent=indent)

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -89,6 +89,7 @@ end
 @test sprint(JSON.show_json, JSON.StandardSerialization(), view([184], 1)) == "184"
 
 # test serializing with a JSONText object
-@test json([JSONText("{\"bar\":[3,4,5]}"),314159]) == "[{\"bar\":[3,4,5]},314159]"
+@test json([JSONText("{\"bar\":  [3,4,5]}"),314159]) == "[{\"bar\":  [3,4,5]},314159]"
+@test json([JSONText("{\"bar\":  [3,4,5]}"),314159], 0) == "[\n {\n  \"bar\": [\n   3,\n   4,\n   5\n  ]\n },\n 314159\n]\n"
 
 end

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -88,4 +88,7 @@ end
 # issue #184: serializing a 0-dimensional array
 @test sprint(JSON.show_json, JSON.StandardSerialization(), view([184], 1)) == "184"
 
+# test serializing with a JSONText object
+@test json([JSONText("{\"bar\":[3,4,5]}"),314159]) == "[{\"bar\":[3,4,5]},314159]"
+
 end

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -90,6 +90,6 @@ end
 
 # test serializing with a JSONText object
 @test json([JSONText("{\"bar\":  [3,4,5]}"),314159]) == "[{\"bar\":  [3,4,5]},314159]"
-@test json([JSONText("{\"bar\":  [3,4,5]}"),314159], 0) == "[\n {\n  \"bar\": [\n   3,\n   4,\n   5\n  ]\n },\n 314159\n]\n"
+@test json([JSONText("{\"bar\":  [3,4,5]}"),314159], 1) == "[\n {\n  \"bar\": [\n   3,\n   4,\n   5\n  ]\n },\n 314159\n]\n"
 
 end


### PR DESCRIPTION
This exports a `JSONText(s::String)` object that you can use to embed raw JSON in directly in the output.

For example, this would be useful in IJulia for JuliaLang/IJulia.jl#621