### PR TITLE
A few performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@ os:
     - linux
 julia:
     - 0.7
+    - 1.0
     - nightly
 notifications:
     email: false
-sudo: false
-script:
-    - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("JSON"); Pkg.test("JSON"; coverage=true)';
 after_success:
-    - julia -e 'cd(Pkg.dir("JSON")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
+    - julia -e 'import Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,18 @@
 environment:
   matrix:
   - julia_version: 0.7
-  - julia_version: latest
+  - julia_version: 1
+  - julia_version: nightly
 
 platform:
   - x86 # 32-bit
   - x64 # 64-bit
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
-#  - julia_version: latest
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
@@ -34,3 +35,9 @@ build_script:
 test_script:
   - echo "%JL_TEST_SCRIPT%"
   - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -330,8 +330,9 @@ function int_from_bytes(pc::ParserContext{<:Any,IntType},
     num = IntType(0)
     @inbounds for i in from:to
         c = bytes[i]
-        if isjsondigit(c)
-            num = IntType(10) * num + IntType(c - DIGIT_ZERO)
+        dig = c - DIGIT_ZERO
+        if dig < 0x10
+            num = IntType(10) * num + IntType(dig)
         else
             _error(E_BAD_NUMBER, ps)
         end

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -78,9 +78,10 @@ skip past that byte. Otherwise, an error is thrown.
     if byteat(ps) == c
         incr!(ps)
     else
-        _error("Expected '$(Char(c))' here", ps)
+        _error_expected_char(c, ps)
     end
 end
+@noinline _error_expected_char(c, ps) = _error("Expected '$(Char(c))' here", ps)
 
 function skip!(ps::ParserState, cs::UInt8...)
     for c in cs


### PR DESCRIPTION
Commit 1 works around the slow dynamic dispatch that currently exist in Base (https://github.com/JuliaLang/julia/issues/29887). This significantly reduces the overhead of creating the Parser:

Before:

```jl
julia> @btime JSON.parse("\"foo\"")
  3.080 μs (2 allocations: 64 bytes)
"foo"
```

After:
```jl
julia> @btime JSON.parse("\"foo\"")
  196.499 ns (3 allocations: 160 bytes)
"foo"
```

Note that quite a lot of JSON can be parsed within 3μs.

Commit 2, caches the UInt8 vector which is filled with bytes of digits. Reusing the same vector has a bunch of benefits in terms of not having to grow it over and over and the data will be hot.

Using the benchmark

```jl
julia> using Random

julia> a = string("[", join([rand(Int) for i in 1:10^3], ","), "]");
```

Before:

```jl
julia> @btime JSON.parse($a)
  352.473 μs (6011 allocations: 250.86 KiB)
```

After:

```jl
julia> @btime JSON.parse($a)
  228.998 μs (1016 allocations: 32.33 KiB)
```

The third commit doesn't at the moment not have much of a significant performance change but it should be strictly less work for not really more complicated code so why not? :)
