### PR TITLE
restore special case parsing of numbers for in memory JSON

### DIFF
--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -20,13 +20,12 @@ abstract type ParserState end
 mutable struct MemoryParserState <: ParserState
     utf8::String
     s::Int
-    utf8array::Vector{UInt8}
 end
 
 # it is convenient to access MemoryParserState like a Vector{UInt8} to avoid copies
 Base.@propagate_inbounds Base.getindex(state::MemoryParserState, i::Int) = codeunit(state.utf8, i)
 Base.length(state::MemoryParserState) = sizeof(state.utf8)
-Base.unsafe_convert(::Type{Ptr{UInt8}}, state::MemoryParserState) = unsafe_convert(Ptr{UInt8}, state.utf8)
+Base.unsafe_convert(::Type{Ptr{UInt8}}, state::MemoryParserState) = Base.unsafe_convert(Ptr{UInt8}, state.utf8)
 
 mutable struct StreamingParserState{T <: IO} <: ParserState
     io::T
@@ -409,7 +408,7 @@ function parse(str::AbstractString;
                dicttype=Dict{String,Any},
                inttype::Type{<:Real}=Int64)
     pc = _get_parsercontext(dicttype, inttype)
-    ps = MemoryParserState(str, 1, UInt8[])
+    ps = MemoryParserState(str, 1)
     v = parse_value(pc, ps)
     chomp_space!(ps)
     if hasmore(ps)

--- a/src/specialized.jl
+++ b/src/specialized.jl
@@ -120,7 +120,7 @@ function parse_string(ps::MemoryParserState, b::IOBuffer)
     b
 end
 
-function parse_number(ps::MemoryParserState)
+function parse_number(pc::ParserContext, ps::MemoryParserState)
     s = p = ps.s
     e = length(ps)
     isint = true
@@ -140,5 +140,5 @@ function parse_number(ps::MemoryParserState)
     end
     ps.s = p
 
-    number_from_bytes(ps, isint, ps, s, p - 1)
+    number_from_bytes(pc, ps, isint, ps, s, p - 1)
 end


### PR DESCRIPTION
I was trying to figure out why the `from` and `to` variables where threaded through the number routines since it seemed like they were always `1` and `length(ps.utf8array)` respectively. Turns out there is a currently unused special cased number parser is being failed to dispatched to after the introduction of `ParserContext` (https://github.com/JuliaIO/JSON.jl/pull/224 cc @kmsquire).

This restores the special case for a nice performance boost:

```jl
using JSON
using BenchmarkTools

a = string("[", join([rand(Int) for i in 1:10^3], ","), "]");
@btime JSON.parse($a)
```

Before:

```
julia> @btime JSON.parse($a)
  246.210 μs (1016 allocations: 32.33 KiB)
```

After:

```
julia> @btime JSON.parse($a)
  89.930 μs (1011 allocations: 32.11 KiB)
```