### PR TITLE
Fix indexing of ESCAPED_ARRAY

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -121,10 +121,10 @@ const SC = StructuralContext
 # Low-level direct access
 Base.write(io::JSONContext, byte::UInt8) = write(io.io, byte)
 Base.write(io::StringContext, byte::UInt8) =
-    write(io.io, ESCAPED_ARRAY[byte + 0x01])
+    write(io.io, ESCAPED_ARRAY[byte + 1])
 #= turn on if there's a performance benefit
 write(io::StringContext, char::Char) =
-    char <= '\x7f' ? write(io, ESCAPED_ARRAY[UInt8(c) + 0x01]) :
+    char <= '\x7f' ? write(io, ESCAPED_ARRAY[UInt8(c) + 1]) :
                      Base.print(io, c)
 =#
 

--- a/test/standard-serializer.jl
+++ b/test/standard-serializer.jl
@@ -49,6 +49,13 @@ end
     @test JSON.parse(json_zeros) == zeros
 end
 
+@testset "All bytes" begin
+    str = String(collect(0x00:0xff))
+    bytes = Dict(str => str)
+    json_bytes = json(bytes)
+    @test JSON.parse(json_bytes) == bytes
+end
+
 @testset "Arrays" begin
     # Printing an empty array or Dict shouldn't cause a BoundsError
     @test json(String[]) == "[]"


### PR DESCRIPTION
Fixes the `BoundsError: attempt to access 256-element Array{Array{UInt8,1},1} at index [0]` error that occurs when serializing a string containing the byte `0xff`.