### PR TITLE
Made `show_json` for composite types more flexible via `propertynames`/`getproperty`.

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -20,7 +20,7 @@ struct CompositeTypeWrapper{T}
 end
 
 CompositeTypeWrapper(x, syms) = CompositeTypeWrapper(x, collect(syms))
-CompositeTypeWrapper(x) = CompositeTypeWrapper(x, fieldnames(typeof(x)))
+CompositeTypeWrapper(x) = CompositeTypeWrapper(x, propertynames(x))
 
 """
     lower(x)
@@ -282,7 +282,7 @@ end
 function show_json(io::SC, s::CS, x::CompositeTypeWrapper)
     begin_object(io)
     for fn in x.fns
-        show_pair(io, s, fn, getfield(x.wrapped, fn))
+        show_pair(io, s, fn, getproperty(x.wrapped, fn))
     end
     end_object(io)
 end

--- a/test/lowering.jl
+++ b/test/lowering.jl
@@ -24,7 +24,7 @@ JSON.lower(v::Type151{T}) where {T} = Dict(:type => T, :value => v.x)
 fixednum = Fixed{Int16, 15}(0.1234)
 @test JSON.parse(JSON.json(fixednum)) == convert(Float64, fixednum)
 
-# test that the default string-serialization of enums can be overriden by
+# test that the default string-serialization of enums can be overridden by
 # `lower` if needed
 @enum Fruit apple orange banana
 JSON.lower(x::Fruit) = string("Fruit: ", x)
@@ -33,5 +33,14 @@ JSON.lower(x::Fruit) = string("Fruit: ", x)
 @enum Vegetable carrot tomato potato
 JSON.lower(x::Vegetable) = Dict(string(x) => Int(x))
 @test JSON.json(potato) == "{\"potato\":2}"
+
+# test that the default lowering for compound types can be overridden by `propertynames` and
+# `getproperty` if needed
+struct Type152
+    x::Int
+end
+Base.propertynames(v::Type152) = (:type, fieldnames(Type152)...)
+Base.getproperty(v::Type152, s::Symbol) = s == :type ? :Type152 : getfield(v, s)
+@test JSON.json(Type152(152)) == "{\"type\":\"Type152\",\"x\":152}"
 
 end


### PR DESCRIPTION
This lets `show_json(..., ::CompositeTypeWrapper)` potentially do more interesting things by providing a custom `getproperty` method.

~It also has `show_json` apply `something` to values of type `Some`.~ I decided it would be safer not to assume this is always the desired behavior.