### PR TITLE
Allow specifying a value to use when parsing null

### DIFF
--- a/test/parser/null.jl
+++ b/test/parser/null.jl
@@ -1,0 +1,7 @@
+@testset "Custom null values" begin
+    s = "{\"x\": null}"
+    for null in (nothing, missing)
+        val = JSON.parse(s, null=null)
+        @test val["x"] === null
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,10 @@ include("json-samples.jl")
         include("parser/nan-inf.jl")
     end
 
+    @testset "null" begin
+        include("parser/null.jl")
+    end
+
     @testset "Miscellaneous" begin
         # test for single values
         @test JSON.parse("true") == true


### PR DESCRIPTION
Currently both `nothing` and `missing` are written to JSON files as `null`, but parsing such files results in `nothing`. Now the user can pass a `null=` keyword argument to `parse` and `parsefile` to specify the Julia value that results from parsing JSON's `null`.