### PR TITLE
Fix wrong format of float on nightly build julia

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -254,9 +254,21 @@ function show_json(io::SC, s::CS, x::IsPrintedAsString)
     end
 end
 
-function show_json(io::SC, s::CS, x::Union{Integer, AbstractFloat})
-    if isfinite(x)
-        Base.print(io, x)
+function show_json(io::SC, s::CS, i::Integer)
+    Base.print(io, i)
+end
+
+function show_json(io::SC, s::CS, f::AbstractFloat)
+    if isfinite(f)
+        str = string(f)
+        # use 'f' for exponent is not allowed in JSON
+        for i in 1:lastindex(str)
+            if str[i] == 'f'
+                Base.print(io, join([str[1:i-1], "e", str[i+1:lastindex(str)]]))
+                return
+            end
+        end
+        Base.print(io, str)
     else
         show_null(io)
     end

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -261,14 +261,7 @@ end
 function show_json(io::SC, s::CS, f::AbstractFloat)
     if isfinite(f)
         str = string(f)
-        # use 'f' for exponent is not allowed in JSON
-        for i in 1:lastindex(str)
-            if str[i] == 'f'
-                Base.print(io, join([str[1:i-1], "e", str[i+1:lastindex(str)]]))
-                return
-            end
-        end
-        Base.print(io, str)
+        Base.print(io, convert(Float64, f))
     else
         show_null(io)
     end


### PR DESCRIPTION
As mentioned in #294, `JSON.json(2.1f-8)` produce `"2.1f-8"` on nightly build julia; but this is bad format because JSON standard does not allow using 'f' for exponent. ( see https://www.json.org )
So I fixed to print 'e' instead of 'f' as exponent prefix in the function `show_json`.

fixes #294 