### PR TITLE
Print longer arrays without newlines

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -287,12 +287,12 @@ function show_json(io::SC, s::CS, x::CompositeTypeWrapper)
     end_object(io)
 end
 
-function show_json(io::SC, s::CS, x::Union{AbstractVector, Tuple}; do_newlines = length(x) <= 5)
+function show_json(io::SC, s::CS, x::Union{AbstractVector, Tuple}; newline::Bool = true)
     begin_array(io)
     for elt in x
-        show_element(io, s, elt, newline = do_newlines)
+        show_element(io, s, elt, newline = newline)
     end
-    end_array(io, newline = do_newlines)
+    end_array(io, newline = newline)
 end
 
 """
@@ -327,6 +327,14 @@ function show_json(io::IO, s::Serialization, obj; indent=nothing)
         println(io)
     end
 end
+function show_json(io::IO, s::Serialization, obj::Union{AbstractVector, Tuple}; indent=nothing, newline=true)
+    ctx = indent === nothing ? CompactContext(io) : PrettyContext(io, indent)
+    show_json(ctx, s, obj, newline=newline)
+    if indent !== nothing
+        println(io)
+    end
+end
+
 
 """
     JSONText(s::AbstractString)
@@ -347,6 +355,12 @@ show_json(io::CompactContext, s::CS, json::JSONText) = write(io, json.s)
 print(io::IO, obj, indent) =
     show_json(io, StandardSerialization(), obj; indent=indent)
 print(io::IO, obj) = show_json(io, StandardSerialization(), obj)
+
+print(io::IO, obj::Union{AbstractVector, Tuple}, indent; newline::Bool = length(obj) <= 5) =
+    show_json(io, StandardSerialization(), obj; indent=indent, newline=newline)
+print(io::IO, obj::Union{AbstractVector, Tuple}; newline::Bool = length(obj) <= 5) = 
+    show_json(io, StandardSerialization(), obj, newline=newline)
+
 
 print(a, indent) = print(stdout, a, indent)
 print(a) = print(stdout, a)

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -129,18 +129,18 @@ write(io::StringContext, char::Char) =
 =#
 
 """
-    indent(io::StructuralContext)
+    indent(io::StructuralContext; newline = true)
 
 If appropriate, write a newline to the given context, then indent it by the
 appropriate number of spaces. Otherwise, do nothing.
 """
-@inline function indent(io::PrettyContext)
-    write(io, NEWLINE)
+@inline function indent(io::PrettyContext; newline = true)
+    newline && write(io, NEWLINE)
     for _ in 1:io.state
         write(io, SPACE)
     end
 end
-@inline indent(io::CompactContext) = nothing
+@inline indent(io::CompactContext; newline = true) = nothing
 
 """
     separate(io::StructuralContext)
@@ -212,9 +212,9 @@ show_null(io::IO) = Base.print(io, "null")
 Print object `x` as an element of a JSON array to context `io` using rules
 defined by serialization `s`.
 """
-function show_element(io::JSONContext, s, x)
+function show_element(io::JSONContext, s, x; newline = true)
     delimit(io)
-    indent(io)
+    indent(io, newline = newline)
     show_json(io, s, x)
 end
 
@@ -289,8 +289,9 @@ end
 
 function show_json(io::SC, s::CS, x::Union{AbstractVector, Tuple})
     begin_array(io)
+    do_newlines = length(x) <= 5
     for elt in x
-        show_element(io, s, elt)
+        show_element(io, s, elt, newline = do_newlines)
     end
     end_array(io)
 end


### PR DESCRIPTION
Saving JSON files with long arrays results in very long documents currently because of all the newlines.
This only prints newlines after array elements if the length of the array is > 5.

i.e.

```
{
  "x": [1,2,3,4,5,6,7,8,9,10]
}
```
instead of
```
{
  "x": [
    1,
    2,
    3,
    4,
    5,
    6,
    7,
    8,
    9,
    10
 ]
}
```

Fixes #291 