### PR TITLE
Compat entry for Parsers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "0.7, 1.0"
+Parsers = "0 - 1"
 
 [targets]
 test = ["DataStructures", "Distributed", "FixedPointNumbers", "OffsetArrays", "Sockets", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "0.7, 1.0"
-Parsers = "0 - 1"
+Parsers = "0.1, 0.2, 0.3, 1"
 
 [targets]
 test = ["DataStructures", "Distributed", "FixedPointNumbers", "OffsetArrays", "Sockets", "Test"]


### PR DESCRIPTION
JSON.jl currently has an unbounded dependency - this PR sets the compatibility range to `[0.0.0 - 2.0.0)`, which includes all versions currently supported, but sets an upper bound at `v2.0.0`.

(I'm only creating this minor PR because [JSON.jl has so many dependents](https://www.juliahub.com/ui/Packages/JSON/uf6oy/0.21.0?t=2).)