### PR TITLE
revert 1.0 bump and tag + release 0.21.1 instead

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.0.0"
+version = "0.21.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
This allows us to get a new JSON version out to everyone with the latest bugfixes and improvements.