### PR TITLE
RFC: Add `indent` keyword argument for `JSON.json`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ JSON.json([2,3])
 #  "[2,3]"
 JSON.json(j)
 #  "{\"an_array\":[\"string\",9],\"a_number\":5.0}"
+
+# indenting pretty-print 
+print(JSON.json(j, indent=4))
+#{
+#    "an_array": [
+#        "string",
+#        9
+#    ],
+#    "a_number": 5.0
+#}
 ```
 
 ## Documentation

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -358,11 +358,11 @@ print(a) = print(stdout, a)
 Creates a JSON string from a Julia object or value.
 
 Arguments:
-  • a: the Julia object or value to encode
-  • indent (optional number): if provided, pretty-print array and object
+  * a: the Julia object or value to encode
+  * indent (optional number): if provided, pretty-print array and object
     substructures by indenting with the provided number of spaces
 """
-json(a; indent=nothing) = ifelse(indent===nothing, sprint(print, a), sprint(print, a, indent))
+json(a; indent=nothing) = indent === nothing ? sprint(print, a) : sprint(print, a, indent)
 json(a, indent) = sprint(print, a, indent)
 
 end

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -352,7 +352,7 @@ print(a, indent) = print(stdout, a, indent)
 print(a) = print(stdout, a)
 
 """
-    json(a)
+    json(a; indent=nothing)
     json(a, indent::Int)
 
 Creates a JSON string from a Julia object or value.
@@ -362,7 +362,7 @@ Arguments:
   • indent (optional number): if provided, pretty-print array and object
     substructures by indenting with the provided number of spaces
 """
-json(a) = sprint(print, a)
+json(a; indent=nothing) = ifelse(indent===nothing, sprint(print, a), sprint(print, a, indent))
 json(a, indent) = sprint(print, a, indent)
 
 end

--- a/test/indentation.jl
+++ b/test/indentation.jl
@@ -8,3 +8,7 @@ ev = JSON.parse(svg_tviewer_menu)
 ejson1 = json(ev, 2)
 ejson2 = json(ev)
 @test JSON.parse(ejson1) == JSON.parse(ejson2)
+
+# check `indent` keyword argument works as same as second  positional argument (ref: gh-193
+@test json(fb, 2) == json(fb, indent=2)
+


### PR DESCRIPTION
I added a `indent` keyword argument for `JSON.json` to fix #193.
Also, I added a test for it and update README to explain it. 