### PR TITLE
Add eof check for streaming parser

### DIFF
--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -105,7 +105,7 @@ Return `true` if there is a current byte, and `false` if all bytes have been
 exausted.
 """
 @inline hasmore(ps::MemoryParserState) = ps.s ≤ length(ps)
-@inline hasmore(ps::StreamingParserState) = true  # no more now ≠ no more ever
+@inline hasmore(ps::StreamingParserState) = !ps.used || !eof(ps.io)
 
 """
 Remove as many whitespace bytes as possible from the `ParserState` starting from

--- a/test/regression/issue314.jl
+++ b/test/regression/issue314.jl
@@ -1,0 +1,2 @@
+@test JSON.parse(IOBuffer("123")) == 123
+@test JSON.parse(IOBuffer("1.5")) == 1.5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,7 +80,7 @@ end
 end
 
 @testset "Regression" begin
-    @testset "for issue #$i" for i in [21, 26, 57, 109, 152, 163]
+    @testset "for issue #$i" for i in [21, 26, 57, 109, 152, 163, 314]
         include("regression/issue$(lpad(string(i), 3, "0")).jl")
     end
 end


### PR DESCRIPTION
## Summary

Adds an end of file check to the streaming parser.

## Motivation

```julia
# This works
JSON.parse("123")

# This also wrks
JSON.parse(IOBuffer("123\n"))

# This breaks
JSON.parse(IOBuffer("123"))
```

Fixes #314