### PR TITLE
implement printfile (complementary to parsefile)

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -21,7 +21,7 @@ using .Parser: parse, parsefile
 using .Writer: show_json, json, lower, print, StructuralContext, show_element,
                show_string, show_key, show_pair, show_null, begin_array,
                end_array, begin_object, end_object, indent, delimit, separate,
-               JSONText
+               JSONText, printfile
 using .Serializations: Serialization, CommonSerialization,
                        StandardSerialization
 

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -352,6 +352,15 @@ print(a, indent) = print(stdout, a, indent)
 print(a) = print(stdout, a)
 
 """
+    printfile(filename::AbstractString, printargs...)
+
+A convenience wrapper that opens the `filename` for writing and prints the JSON
+to it. All arguments other than `filename` are forwarded to `print`.
+"""
+printfile(filename::AbstractString, printargs...) =
+    open(io -> print(io, printargs...), filename, "w")
+
+"""
     json(a)
     json(a, indent::Int)
 

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -85,6 +85,13 @@ let filename = tempname()
     rm(filename)
 end
 
+# test convenience printing to file
+let filename = tempname()
+    JSON.printfile(filename, Any[1, 2, 3.0])
+    @test read(filename, String) == "[1,2,3.0]"
+    rm(filename)
+end
+
 # issue #184: serializing a 0-dimensional array
 @test sprint(JSON.show_json, JSON.StandardSerialization(), view([184], 1)) == "184"
 


### PR DESCRIPTION
Hello,

`printfile` seems like a nice convenience function to have to me. I know that it's kindof redundant, but it really simplifies the package use when you just want to dump something to JSON (e.g. bioinformaticians won't need to think about how to construct the lambda in `open` :] ). API-wise I find it nicely complementary to `parsefile`.

Closes #325 

Also closes https://github.com/LCSB-BioCore/COBREXA.jl/issues/397 (a typical usecase.)

I'm not sure if `printfile` name is the best one, feel free to change/suggest a better one.

Thanks & best,
-mk