### PR TITLE
Update Parsers support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "0.7, 1.0"
-Parsers = "0.1, 0.2, 0.3, 1"
+Parsers = "1, 2"
 
 [targets]
 test = ["DataStructures", "Distributed", "FixedPointNumbers", "OffsetArrays", "Sockets", "Test"]

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -319,7 +319,7 @@ byte before `to`. Bytes enclosed should all be ASCII characters.
 float_from_bytes(bytes::MemoryParserState, from::Int, to::Int) = float_from_bytes(bytes.utf8, from, to)
 
 function float_from_bytes(bytes::Union{String, Vector{UInt8}}, from::Int, to::Int)::Union{Float64,Nothing}
-    return Parsers.tryparse(Float64, bytes isa String ? SubString(bytes, from, to) : view(bytes, from, to))
+    return Parsers.tryparse(Float64, bytes isa String ? SubString(bytes, from:to) : view(bytes, from:to))
 end
 
 """

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -319,17 +319,7 @@ byte before `to`. Bytes enclosed should all be ASCII characters.
 float_from_bytes(bytes::MemoryParserState, from::Int, to::Int) = float_from_bytes(bytes.utf8, from, to)
 
 function float_from_bytes(bytes::Union{String, Vector{UInt8}}, from::Int, to::Int)::Union{Float64,Nothing}
-    # Would like to use tryparse, but we want it to consume the full input,
-    # and the version in Parsers does not do this.
-
-    # return Parsers.tryparse(Float64, @view bytes.utf8[from:to])
-
-    len = to - from + 1
-    x, code, vpos, vlen, tlen = Parsers.xparse(Float64, bytes, from, to, Parsers.OPTIONS)
-    if !Parsers.ok(code) || vlen < len
-        return nothing
-    end
-    return x::Float64
+    return Parsers.tryparse(Float64, @view bytes[from:to])
 end
 
 """

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -319,7 +319,7 @@ byte before `to`. Bytes enclosed should all be ASCII characters.
 float_from_bytes(bytes::MemoryParserState, from::Int, to::Int) = float_from_bytes(bytes.utf8, from, to)
 
 function float_from_bytes(bytes::Union{String, Vector{UInt8}}, from::Int, to::Int)::Union{Float64,Nothing}
-    return Parsers.tryparse(Float64, @view bytes[from:to])
+    return Parsers.tryparse(Float64, bytes isa String ? SubString(bytes, from, to) : view(bytes, from, to))
 end
 
 """

--- a/test/json-checker.jl
+++ b/test/json-checker.jl
@@ -1,6 +1,6 @@
 # Run modified JSON checker tests
 
-const JSON_DATA_DIR = joinpath(dirname(@__DIR__), "data")
+const JSON_DATA_DIR = joinpath(dirname(pathof(JSON)), "../data")
 
 for i in 1:38
     file = "fail$(lpad(string(i), 2, "0")).json"


### PR DESCRIPTION
Update the Parsers compat versions to `"1, 2"`. As of v1.0.5,
`Parsers.tryparse` ensured the full input buffer was consumed when
parsing a value (as mentioned desirable in the now-deleted comment in
`float_from_bytes`). So dropping support for older Parsers versions
allows us to trust `Parsers.tryparse`, and those pre-1.0 versions are
pretty old at this point anyway.

I locally ran the JSON.jl tests under both Parsers v2.0.1 and v1.1.1 and
ensured both were passing, so it shouldn't matter which version of
Parsers ends up getting installed if there are other packages which
don't 2.0 yet.