### PR TITLE
RFC: Add singleton type support

### DIFF
--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -365,4 +365,6 @@ Arguments:
 json(a) = sprint(print, a)
 json(a, indent) = sprint(print, a, indent)
 
+Base.show(io::IOContext, ::MIME{Symbol("application/json")}, x::Any) = print(io, x)
+
 end

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -365,6 +365,6 @@ Arguments:
 json(a) = sprint(print, a)
 json(a, indent) = sprint(print, a, indent)
 
-Base.show(io::IOContext, ::MIME{Symbol("application/json")}, x::Any) = print(io, x)
+Base.show(io::IO, ::MIME{Symbol("application/json")}, x::Any) = print(io, x)
 
 end

--- a/test/serializer.jl
+++ b/test/serializer.jl
@@ -70,9 +70,17 @@ end
 ]
 """
 
-# test serializing a type without any fields
+# test serializing a singleton
 struct SingletonType end
-@test_throws ErrorException json(SingletonType())
+@test Base.issingletontype(SingletonType) # sanity test
+@test json(SingletonType()) == json(SingletonType)
+@test json(SingletonType()) == json(SingletonType())
+
+# test serializing a singleton with parameters
+struct ParamSingletonType{T} end
+@test json(ParamSingletonType{Float64}()) == json(ParamSingletonType{Float64})
+@test json(ParamSingletonType{Float64}()) == json(ParamSingletonType{Float64}())
+@test json(ParamSingletonType{Float64}()) != json(ParamSingletonType{Float32}())
 
 # test printing to stdout
 let filename = tempname()

--- a/test/standard-serializer.jl
+++ b/test/standard-serializer.jl
@@ -30,6 +30,18 @@ end
     @test sprint(JSON.print, Float64) == string("\"Float64\"")
 end
 
+@testset "Singletons" begin
+    struct SingletonType end
+    struct ParamSingletonType{T} end
+    
+    @test Base.issingletontype(SingletonType) # sanity test
+    @test sprint(JSON.print, SingletonType()) == string("\"SingletonType\"")
+    @test sprint(JSON.print, SingletonType) == string("\"SingletonType\"")
+
+    @test sprint(JSON.print, ParamSingletonType{Float64}()) == string("\"ParamSingletonType{Float64}\"")
+    @test sprint(JSON.print, ParamSingletonType{Float64}) == string("\"ParamSingletonType{Float64}\"")
+end
+
 @testset "Module" begin
     @test_throws ArgumentError sprint(JSON.print, JSON)
 end

--- a/test/standard-serializer.jl
+++ b/test/standard-serializer.jl
@@ -30,9 +30,10 @@ end
     @test sprint(JSON.print, Float64) == string("\"Float64\"")
 end
 
+struct SingletonType end
+struct ParamSingletonType{T} end
+
 @testset "Singletons" begin
-    struct SingletonType end
-    struct ParamSingletonType{T} end
     
     @test Base.issingletontype(SingletonType) # sanity test
     @test sprint(JSON.print, SingletonType()) == string("\"SingletonType\"")

--- a/test/standard-serializer.jl
+++ b/test/standard-serializer.jl
@@ -38,9 +38,11 @@ struct ParamSingletonType{T} end
     @test Base.issingletontype(SingletonType) # sanity test
     @test sprint(JSON.print, SingletonType()) == string("\"SingletonType\"")
     @test sprint(JSON.print, SingletonType) == string("\"SingletonType\"")
+    @test Base.repr(MIME"application/json"(), SingletonType) == string("\"SingletonType\"")
 
     @test sprint(JSON.print, ParamSingletonType{Float64}()) == string("\"ParamSingletonType{Float64}\"")
     @test sprint(JSON.print, ParamSingletonType{Float64}) == string("\"ParamSingletonType{Float64}\"")
+    @test Base.repr(MIME"application/json"(), ParamSingletonType{Float64}) == string("\"ParamSingletonType{Float64}\"")
 end
 
 @testset "Module" begin


### PR DESCRIPTION
This adds support for writing singleton types, and hopefully will also support serialization

The idea is that Singleton types (specifically types without properties) are identical unless they're parametric.  Currently this just prints the type of the singleton, which means there's no way to distinguish a saved type versus an instantiated singleton object