### PR TITLE
Update doc with correct parameterized function syntax

### DIFF
--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -425,11 +425,11 @@ function _get_parsercontext(dicttype, inttype, allownan, null)
 end
 
 """
-    parse{T<:Associative}(str::AbstractString;
+    parse(str::AbstractString;
                           dicttype::Type{T}=Dict,
                           inttype::Type{<:Real}=Int64,
                           allownan::Bool=true,
-                          null=nothing)
+                          null=nothing) where {T<:Associative}
 
 Parses the given JSON string into corresponding Julia types.
 
@@ -456,11 +456,11 @@ function parse(str::AbstractString;
 end
 
 """
-    parse{T<:Associative}(io::IO;
+    parse(io::IO;
                           dicttype::Type{T}=Dict,
                           inttype::Type{<:Real}=Int64,
                           allownan=true,
-                          null=nothing)
+                          null=nothing) where {T<:Associative}
 
 Parses JSON from the given IO stream into corresponding Julia types.
 

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -429,7 +429,7 @@ end
           dicttype::Type{T}=Dict,
           inttype::Type{<:Real}=Int64,
           allownan::Bool=true,
-          null=nothing) where {T<:Associative}
+          null=nothing) where {T<:AbstractDict}
 
 Parses the given JSON string into corresponding Julia types.
 

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -460,7 +460,7 @@ end
           dicttype::Type{T}=Dict,
           inttype::Type{<:Real}=Int64,
           allownan=true,
-          null=nothing) where {T<:Associative}
+          null=nothing) where {T<:AbstractDict}
 
 Parses JSON from the given IO stream into corresponding Julia types.
 

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -426,10 +426,10 @@ end
 
 """
     parse(str::AbstractString;
-                          dicttype::Type{T}=Dict,
-                          inttype::Type{<:Real}=Int64,
-                          allownan::Bool=true,
-                          null=nothing) where {T<:Associative}
+          dicttype::Type{T}=Dict,
+          inttype::Type{<:Real}=Int64,
+          allownan::Bool=true,
+          null=nothing) where {T<:Associative}
 
 Parses the given JSON string into corresponding Julia types.
 
@@ -457,10 +457,10 @@ end
 
 """
     parse(io::IO;
-                          dicttype::Type{T}=Dict,
-                          inttype::Type{<:Real}=Int64,
-                          allownan=true,
-                          null=nothing) where {T<:Associative}
+          dicttype::Type{T}=Dict,
+          inttype::Type{<:Real}=Int64,
+          allownan=true,
+          null=nothing) where {T<:Associative}
 
 Parses JSON from the given IO stream into corresponding Julia types.
 


### PR DESCRIPTION
This format is not supported since a long time.
Should we remap Associative to AbstractDict too ?