### PR TITLE
add basic precompilation

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -29,6 +29,7 @@ using .Serializations: Serialization, CommonSerialization,
 Writer.lower(json::JSONText) = parse(json.s)
 
 function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     x =  "{\"type\":\"callback\",\"data\":{\"callback\":1,\"result\":true,\"error\":false}}"
     JSON.lower(JSON.parse(x))
 end

--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -28,4 +28,11 @@ using .Serializations: Serialization, CommonSerialization,
 # for pretty-printed (non-compact) output, JSONText must be re-parsed:
 Writer.lower(json::JSONText) = parse(json.s)
 
+function _precompile_()
+    x =  "{\"type\":\"callback\",\"data\":{\"callback\":1,\"result\":true,\"error\":false}}"
+    JSON.lower(JSON.parse(x))
+end
+
+_precompile_()
+
 end # module


### PR DESCRIPTION
This tiny PR Improves the ttfx time of Blink.jl by 5 seconds. Probably also helps other packages that use JSON.jl

Current master here and with Blink.jl:
```julia
julia> @time using Blink
  5.583824 seconds (17.56 M allocations: 740.126 MiB, 6.44% gc time, 88.95% compilation time)

julia> @time Window()
 12.164188 seconds (28.92 M allocations: 1.293 GiB, 3.17% gc time, 98.19% compilation time)
Window(1, Electron(Process(`/home/raf/.julia/dev/Blink/deps/atom/electron /home/raf/.julia/dev/Blink/src/AtomShell/main.js port 3466`, ProcessRunning), Sockets.TCPSocket(RawFD(22) active, 0 bytes waiting), Dict{String, Any}("callback" => Blink.var"#1#2"())), Page(1, WebSocket(server, CONNECTED), Dict{String, Any}("webio" => Blink.AtomShell.var"#22#23"{Blink.AtomShell.WebIOBlinkComm}(Blink.AtomShell.WebIOBlinkComm(Window(#= circular reference @-5 =#))), "callback" => Blink.var"#1#2"()), Distributed.Future(1, 1, 1, Some(true))), Task (done) @0x00007fdcd5809cd0)
```

This PR:
```julia
julia> @time using Blink
  5.477089 seconds (17.55 M allocations: 739.919 MiB, 6.47% gc time, 88.74% compilation time)

julia> @time Window()
  6.973419 seconds (14.42 M allocations: 779.433 MiB, 3.20% gc time, 97.07% compilation time)
Window(1, Electron(Process(`/home/raf/.julia/dev/Blink/deps/atom/electron /home/raf/.julia/dev/Blink/src/AtomShell/main.js port 4505`, ProcessRunning), Sockets.TCPSocket(RawFD(22) active, 0 bytes waiting), Dict{String, Any}("callback" => Blink.var"#1#2"())), Page(1, WebSocket(server, CONNECTED), Dict{String, Any}("webio" => Blink.AtomShell.var"#22#23"{Blink.AtomShell.WebIOBlinkComm}(Blink.AtomShell.WebIOBlinkComm(Window(#= circular reference @-5 =#))), "callback" => Blink.var"#1#2"()), Distributed.Future(1, 1, 1, Some(true))), Task (done) @0x00007f462344ab30)
```