### PR TITLE
Fix DEFAULT_PARSERCONTEXT, speed up parsing.

### DIFF
--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -415,9 +415,9 @@ function unparameterize_type(T::Type)
 end
 
 # Workaround for slow dynamic dispatch for creating objects
-const DEFAULT_PARSERCONTEXT = ParserContext{Dict{String, Any}, Int64, false, nothing}()
+const DEFAULT_PARSERCONTEXT = ParserContext{Dict{String, Any}, Int64, true, nothing}()
 function _get_parsercontext(dicttype, inttype, allownan, null)
-    if dicttype == Dict{String, Any} && inttype == Int64 && !allownan
+    if dicttype == Dict{String, Any} && inttype == Int64 && allownan
         DEFAULT_PARSERCONTEXT
     else
         ParserContext{unparameterize_type(dicttype), inttype, allownan, null}.instance


### PR DESCRIPTION
Unfortunately this was never updated in #280 to be the correct default, and so has been wrong ever since introduction.