### PR TITLE
fix: proper type promotion for ESCAPED_ARRAY indexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.20.1"
+version = "0.20.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/Writer.jl
+++ b/src/Writer.jl
@@ -121,7 +121,7 @@ const SC = StructuralContext
 # Low-level direct access
 Base.write(io::JSONContext, byte::UInt8) = write(io.io, byte)
 Base.write(io::StringContext, byte::UInt8) =
-    write(io.io, ESCAPED_ARRAY[byte + 0x01])
+    write(io.io, ESCAPED_ARRAY[byte + 1])
 #= turn on if there's a performance benefit
 write(io::StringContext, char::Char) =
     char <= '\x7f' ? write(io, ESCAPED_ARRAY[UInt8(c) + 0x01]) :


### PR DESCRIPTION
Fixes https://github.com/julia-vscode/julia-vscode/issues/3555.

The VS Code extension still uses the 0.20 release series, so I'd like to get this fix in regardless of newer versions/better options being available.