### PR TITLE
Fix precompile condition to check for newer versions of julia

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -1,4 +1,4 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
+VERSION >= v"0.7.0-beta2.199" && __precompile__()
 
 module JSON
 


### PR DESCRIPTION
### Problem
The current condition `VERSION < v"0.7.0-beta2.199" && __precompile__()` mistakenly allows the `__precompile__()` directive to be executed in older versions of Julia, which do not support it. This can lead to errors when using the package in Julia versions prior to 0.7.

### Solution
The condition has been updated to `VERSION >= v"0.7.0-beta2.199" && __precompile__()` to ensure that `__precompile__()` is executed only in newer versions of Julia where it is supported.

### Impact
This fix ensures compatibility with older versions of Julia while maintaining functionality in newer versions. It prevents potential runtime errors for users on Julia 0.6 or earlier.
