### PR TITLE
Catch if infinity returned by `parse_jsconstant ` is `nothing`

### DIFF
--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -174,7 +174,7 @@ end
 function parse_jsconstant(::ParserContext{<:Any,<:Any,AllowNanInf,NullValue},
                           ps::ParserState) where {AllowNanInf,NullValue}
     c = advance!(ps)
-    ret = if c == LATIN_T      # true
+    if c == LATIN_T      # true
         skip!(ps, LATIN_R, LATIN_U, LATIN_E)
         true
     elseif c == LATIN_F  # false
@@ -192,7 +192,6 @@ function parse_jsconstant(::ParserContext{<:Any,<:Any,AllowNanInf,NullValue},
     else
         _error(E_UNEXPECTED_CHAR, ps)
     end
-    return ret::Union{Bool, Float64}
 end
 
 function parse_array(pc::ParserContext, ps::ParserState)
@@ -394,6 +393,7 @@ function parse_number(pc::ParserContext{<:Any,<:Any,AllowNanInf}, ps::ParserStat
             isint = false
         elseif AllowNanInf && c == LATIN_UPPER_I
             infinity = parse_jsconstant(pc, ps)
+            infinity === nothing && _error("Invalid infinity value", ps)
             resize!(number, 0)
             return (negative ? -infinity : infinity)
         else

--- a/src/Parser.jl
+++ b/src/Parser.jl
@@ -174,7 +174,7 @@ end
 function parse_jsconstant(::ParserContext{<:Any,<:Any,AllowNanInf,NullValue},
                           ps::ParserState) where {AllowNanInf,NullValue}
     c = advance!(ps)
-    if c == LATIN_T      # true
+    ret = if c == LATIN_T      # true
         skip!(ps, LATIN_R, LATIN_U, LATIN_E)
         true
     elseif c == LATIN_F  # false
@@ -192,6 +192,7 @@ function parse_jsconstant(::ParserContext{<:Any,<:Any,AllowNanInf,NullValue},
     else
         _error(E_UNEXPECTED_CHAR, ps)
     end
+    return ret::Union{Bool, Float64}
 end
 
 function parse_array(pc::ParserContext, ps::ParserState)

--- a/src/specialized.jl
+++ b/src/specialized.jl
@@ -145,6 +145,7 @@ function parse_number(pc::ParserContext{<:Any,<:Any,AllowNanInf}, ps::MemoryPars
         elseif AllowNanInf && LATIN_UPPER_I == c
             ps.s = p
             infinity = parse_jsconstant(pc, ps)
+            infinity === nothing && _error("Invalid infinity value", ps)
             return (negative ? -infinity : infinity)
         else
             break


### PR DESCRIPTION
Fixes
```
  │││││││││┌ parse(str::String) @ JSON.Parser /Users/ian/Documents/GitHub/JSON.jl/src/Parser.jl:443
  ││││││││││┌ parse(str::String; dicttype::Type{Dict{String, Any}}, inttype::Type{Int64}, allownan::Bool, null::Nothing) @ JSON.Parser /Users/ian/Documents/GitHub/JSON.jl/src/Parser.jl:450
  │││││││││││┌ parse_value(pc::JSON.Parser.ParserContext{Dict{String, Any}, Int64, true, nothing}, ps::JSON.Parser.MemoryParserState) @ JSON.Parser /Users/ian/Documents/GitHub/JSON.jl/src/Parser.jl:164
  ││││││││││││┌ parse_number(pc::JSON.Parser.ParserContext{Dict{String, Any}, Int64, true, nothing}, ps::JSON.Parser.MemoryParserState) @ JSON.Parser /Users/ian/Documents/GitHub/JSON.jl/src/specialized.jl:148
  │││││││││││││ no matching method found `-(::Nothing)` (1/3 union split): JSON.Parser.:-(infinity::Union{Nothing, Bool, Float64})
  ││││││││││││└────────────────────
  ││││││││││││┌ parse_number(pc::JSON.Parser.ParserContext{Dict{String, Any}, Int64, true, nothing}, ps::JSON.Parser.MemoryParserState) @ JSON.Parser /Users/ian/Documents/GitHub/JSON.jl/src/specialized.jl:148
  │││││││││││││ no matching method found `-(::Nothing)` (1/3 union split): JSON.Parser.:-(infinity::Union{Nothing, Bool, Float64})::Union{Float64, Int64}
  ││││││││││││└────────────────────
```