### PR TITLE
Add `release` trigger for CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,12 @@
 name: CI
+
 on:
   push:
     branches: [main, master]
     tags: ["*"]
   pull_request:
+  release:
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}


### PR DESCRIPTION
This will allow building docs for stable releases, which is useful for referring to specific versions. If you create a tag `v1.0.0+docs` on the merge commitof this PR it'll create the docs for v1.0.0.