### PR TITLE
Add CI for x86 on ubuntu-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,9 @@ jobs:
           - os: macOS-latest
             arch: aarch64
             version: 1
+          - os: ubuntu-latest
+            arch: x86
+            version: 1
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
I'm updating JSONSchema to v1, and it broke x86:

https://github.com/fredo-dedup/JSONSchema.jl/pull/67
https://github.com/fredo-dedup/JSONSchema.jl/actions/runs/18266053023/job/52000484008?pr=67

Was the choice to not test on an x86 platform deliberate?