### PR TITLE
Audit use of GC.@preserve

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -277,6 +277,7 @@ function applyvalue(f, x::LazyValues, null)
         f(arr)
         return pos
     elseif type == JSONTypes.STRING
+        # TODO: str contains an invalid pointer here
         str, pos = parsestring(x)
         f(convert(String, str))
         return pos
@@ -344,6 +345,7 @@ end
 function StructUtils.lift(style::StructStyle, ::Type{T}, x::LazyValues, tags=(;)) where {T}
     type = gettype(x)
     if type == JSONTypes.STRING
+        # TODO: ptrstr contains an invalid pointer here
         ptrstr, pos = parsestring(x)
         str, _ = StructUtils.lift(style, T, ptrstr, tags)
         return str, pos


### PR DESCRIPTION
Fix one use of GC.@preserve and add TODOs where an invalid pointer escapes GC.@preserve.

@quinnj : Retaining a pointer beyond a `GC.@preserve` is undefined behaviour in Julia, and I've seen at least one case where it causes a real miscompilation.
I've opted not to fix the use of `parsestring` in this PR since that's a larger refactoring that you're best equipped to do. But I've tried to find all the places in the codebase where it's used.