### PR TITLE
Add support for parsing numbers as Int64 to JSONX

### DIFF
--- a/vendor/README.md
+++ b/vendor/README.md
@@ -19,7 +19,7 @@ A simple, no-dependency JSON parser that can be vendored (copied/pasted) into ot
 **Reading (JSON → Julia):**
 - `null` → `nothing`
 - `true`/`false` → `Bool`
-- Numbers → `Float64` (all numbers are parsed as Float64)
+- Numbers → `Int64` or `Float64` (integers without decimal/exponent → Int64, with overflow fallback to Float64)
 - Strings → `String` (with full Unicode support)
 - Arrays → `Vector{Any}`
 - Objects → `Dict{String, Any}`
@@ -80,7 +80,7 @@ JSONX provides detailed error messages for invalid JSON:
 
 Compared to the full JSON.jl package, JSONX is intentionally simplified:
 
-- **No integer parsing**: All numbers are parsed as Float64
+- **Limited numeric types**: Parses as Int64 or Float64 only (no BigInt/BigFloat for very large numbers)
 - **No custom type parsing**: Only returns basic Julia types
 - **No configuration options**: Uses fixed defaults
 - **No streaming**: Loads entire input into memory

--- a/vendor/jsonx.jl
+++ b/vendor/jsonx.jl
@@ -5,7 +5,8 @@ module JSONX
     JSONX.parse(bytes::AbstractVector{UInt8})
 
 Parse a JSON string or byte array and return a Julia value.
-Returns one of: Dict{String, Any}, Vector{Any}, String, Float64, Bool, or Nothing.
+Returns one of: Dict{String, Any}, Vector{Any}, String, Int64, Float64, Bool, or Nothing.
+Numbers without decimal points or exponents are parsed as Int64, falling back to Float64 on overflow.
 """
 function parse(json_str::String)
     pos = 1
@@ -251,10 +252,30 @@ end
 
 function parse_number(str::String, pos::Int, len::Int)
     start_pos = pos
-    while pos <= len && (codeunit(str, pos) == UInt8('-') || (UInt8('0') <= codeunit(str, pos) <= UInt8('9')) || codeunit(str, pos) == UInt8('.') || codeunit(str, pos) == UInt8('e') || codeunit(str, pos) == UInt8('E') || codeunit(str, pos) == UInt8('+'))
-        pos += 1
+    has_decimal_or_exp = false
+    while pos <= len
+        c = codeunit(str, pos)
+        if c == UInt8('-') || (UInt8('0') <= c <= UInt8('9')) || c == UInt8('+')
+            pos += 1
+        elseif c == UInt8('.') || c == UInt8('e') || c == UInt8('E')
+            has_decimal_or_exp = true
+            pos += 1
+        else
+            break
+        end
     end
-    num_str = str[start_pos:pos-1]
+    num_str = @view str[start_pos:pos-1]
+
+    # Try parsing as Int64 if no decimal point or exponent
+    if !has_decimal_or_exp
+        try
+            return Base.parse(Int64, num_str), pos
+        catch
+            # Fall back to Float64 if Int64 parsing fails (e.g., overflow)
+        end
+    end
+
+    # Parse as Float64
     try
         return Base.parse(Float64, num_str), pos
     catch
@@ -339,4 +360,4 @@ function write_object(io::IO, dict::Union{AbstractDict, NamedTuple})
     print(io, '}')
 end
 
-end # module 
+end # module


### PR DESCRIPTION
IJulia recently added a Python integration that involves passing parsed JSON to various Python libraries (https://github.com/JuliaLang/IJulia.jl/pull/1190). Sometimes they can be picky about types, so this PR adds support for parsing as Int64 where possible. Also popped in a `@view` in `parse_number()` to reduce allocations.

Unfortunately I'd say this is a breaking change. Don't think it makes sense to modify the JSON.jl version number, but we could keep a mini-changelog in the README?

Created with help from Claude :robot: 