### PR TITLE
Restore pre-1.0 compat for object Tuple keys

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -16,6 +16,9 @@ StructUtils.lower(::JSONStyle, x::AbstractArray{<:Any,0}) = x[1]
 StructUtils.lower(::JSONStyle, x::AbstractArray{<:Any, N}) where {N} = (view(x, ntuple(_ -> :, N - 1)..., j) for j in axes(x, N))
 StructUtils.lower(::JSONStyle, x::AbstractVector) = x
 
+# for pre-1.0 compat, which serialized Tuple object keys by default
+StructUtils.lowerkey(::JSONStyle, x::Tuple) = string(x)
+
 """
     JSON.omit_null(::Type{T})::Bool
     JSON.omit_null(::JSONStyle, ::Type{T})::Bool

--- a/test/json.jl
+++ b/test/json.jl
@@ -588,6 +588,10 @@ end
             @test result == expected
         end
     end
+
+    @testset "Test pre-1.0 compat for object Tuple keys" begin
+        @test JSON.json(Dict(("a", "b") => 1)) == "{\"(\\\"a\\\", \\\"b\\\")\":1}"
+    end
 end
 
 end # @testset "JSON.json"


### PR DESCRIPTION
Fixes #399 