### PR TITLE
[JSONX] Fix unicode handling when unescaping strings

### DIFF
--- a/vendor/README.md
+++ b/vendor/README.md
@@ -96,3 +96,9 @@ Compared to the full JSON.jl package, JSONX is intentionally simplified:
 - **Error robust**: Comprehensive error checking and reporting
 
 Note: Functions are not exported, so use `JSONX.parse` and `JSONX.json` with the module prefix.
+
+## Changelog
+
+- Fixed unicode handling when unescaping strings (https://github.com/JuliaIO/JSON.jl/pull/405).
+- **Breaking**: Added support for parsing Int64's (https://github.com/JuliaIO/JSON.jl/pull/396).
+- Added `JSONText` (https://github.com/JuliaIO/JSON.jl/pull/394).

--- a/vendor/jsonx.jl
+++ b/vendor/jsonx.jl
@@ -138,10 +138,14 @@ function unescape_string(str::String, start_pos::Int, end_pos::Int)
                 b == 0x00 && throw(ArgumentError("Invalid escape sequence \\$(Char(esc_c))"))
                 print(io, Char(b))
             end
+
+            pos += 1
         else
-            print(io, Char(c))
+            # Regular character
+            print(io, str[pos])
+            pos = nextind(str, pos)
         end
-        pos += 1
+
     end
     return String(take!(io))
 end

--- a/vendor/test.jl
+++ b/vendor/test.jl
@@ -264,6 +264,8 @@ include("jsonx.jl")
         @test JSONX.parse("\"\\uD83C\\uDF55\"") == "🍕"  # Pizza emoji
         # Mixed content
         @test JSONX.parse("\"Hello \\u0041\\u006E\\u0064\\u0072\\u0065\\u0077!\"") == "Hello Andrew!"
+        # String unescaping
+        @test JSONX.parse(raw"\"𝔸\\a\"") == "𝔸\\a"
         # Writing Unicode
         @test JSONX.json("A") == "\"A\""
         @test JSONX.json("😀") == "\"😀\""


### PR DESCRIPTION
Previously `JSONX.unescape_string()` would insert single codeunits at a time into the unescaped output (if the current character is not an escape sequence). This caused characters composed of multiple codeunits to be unescaped as individual characters.

Discovered by Claude when investigating https://github.com/JuliaLang/IJulia.jl/issues/1071#issuecomment-3455145658.