### PR TITLE
Fix getindex(::Object{String}, ::Symbol) and vice versa

### DIFF
--- a/src/object.jl
+++ b/src/object.jl
@@ -138,6 +138,8 @@ function Base.get(f::Base.Callable, obj::Object{K,V}, key) where {K,V}
 end
 
 Base.getindex(obj::Object, key) = get(() -> throw(KeyError(key)), obj, key)
+Base.getindex(obj::Object{String}, key::Symbol) = get(() -> throw(KeyError(key)), obj, String(key))
+Base.getindex(obj::Object{Symbol}, key::String) = get(() -> throw(KeyError(key)), obj, Symbol(key))
 Base.get(obj::Object, key, default) = get(() -> default, obj, key)
 
 # support getproperty for dot access


### PR DESCRIPTION
Currently `haskey(::Object)` is true for both String and Symbol, but `getindex()` doesn't get it.

```julia-repl
julia> o = JSON.parse("""{"a": "a"}""")
julia> haskey(o, :a)
true
julia> o[:a]
ERROR: MethodError: no method matching find_node_by_key(::JSON.Object{String, Any}, ::Symbol)
The function `find_node_by_key` exists, but no method is defined for this combination of argument types.
```
This PR fixes that issue.