### PR TITLE
support both String and Symbol keys for all dict-operations on Objects

### DIFF
--- a/src/object.jl
+++ b/src/object.jl
@@ -140,6 +140,10 @@ end
 Base.getindex(obj::Object, key) = get(() -> throw(KeyError(key)), obj, key)
 Base.getindex(obj::Object{String}, key::Symbol) = get(() -> throw(KeyError(key)), obj, String(key))
 Base.getindex(obj::Object{Symbol}, key::String) = get(() -> throw(KeyError(key)), obj, Symbol(key))
+Base.setindex!(obj::Object{String}, value, key::Symbol) = setindex!(obj, value, String(key))
+Base.setindex!(obj::Object{Symbol}, value, key::String) = setindex!(obj, value, Symbol(key))
+Base.delete!(obj::Object{String}, key::Symbol) = delete!(obj, String(key))
+Base.delete!(obj::Object{Symbol}, key::String) = delete!(obj, Symbol(key))
 Base.get(obj::Object, key, default) = get(() -> default, obj, key)
 
 # support getproperty for dot access
@@ -155,6 +159,7 @@ end
 # haskey
 Base.haskey(obj::Object, key) = find_node_by_key(obj, key) !== nothing
 Base.haskey(obj::Object{String}, key::Symbol) = haskey(obj, String(key))
+Base.haskey(obj::Object{Symbol}, key::String) = haskey(obj, Symbol(key))
 
 # setindex! finds node with key and sets value or inserts a new node
 function Base.setindex!(obj::Object{K,V}, value, key::K) where {K,V}

--- a/test/object.jl
+++ b/test/object.jl
@@ -268,8 +268,59 @@ using JSON, Test
         @test haskey(obj, :symbol_test)
         @test !haskey(obj, :nonexistent_symbol)
 
+        # Test that indexing with both String and Symbol keys work
+        @test obj[:symbol_test] == obj["symbol_test"]
+        
+        # Test overwriting with Symbol key 
+        obj[:symbol_test] = "newvalue"
+        @test obj[:symbol_test] == obj["symbol_test"] == "newvalue"
+
+        # Test deletion with Symbol key
+        delete!(obj, :symbol_test)
+        @test !haskey(obj, :symbol_test)
+        @test !haskey(obj, "symbol_test")
+        
         # Test with empty object
         empty_obj = JSON.Object{String, Any}()
+        @test !haskey(empty_obj, :anything)
+        @test !haskey(empty_obj, "anything")
+    end
+
+    # Test enhanced haskey for Symbol objects with String keys
+    @testset "Enhanced haskey for Symbol Objects" begin
+        obj = JSON.Object{Symbol, Any}()
+        obj[:hello] = "world"
+        obj[:count] = 42
+
+        # Test basic string key lookup
+        @test haskey(obj, :hello)
+        @test haskey(obj, :count)
+        @test !haskey(obj, :missing)
+        
+        # Test String key lookup (should convert to Symbol)
+        @test haskey(obj, "hello")
+        @test haskey(obj, "count")
+        @test !haskey(obj, "missing")
+
+        # Test that String keys work for both existing and non-existing keys
+        obj[:symbol_test] = "value"
+        @test haskey(obj, "symbol_test")
+        @test !haskey(obj, "nonexistent_symbol")
+
+        # Test that indexing with both String and Symbol keys work
+        @test obj[:symbol_test] == obj["symbol_test"]
+
+        # Test overwriting with String key 
+        obj["symbol_test"] = "newvalue"
+        @test obj[:symbol_test] == obj["symbol_test"] == "newvalue"
+
+        # Test deletion with String key
+        delete!(obj, "symbol_test")
+        @test !haskey(obj, :symbol_test)
+        @test !haskey(obj, "symbol_test")
+
+        # Test with empty object
+        empty_obj = JSON.Object{Symbol, Any}()
         @test !haskey(empty_obj, :anything)
         @test !haskey(empty_obj, "anything")
     end


### PR DESCRIPTION
- add methods for `setindex!()`, `delete!()` for `obj::Object{String}`, `key::Symbol` and vice versa
- add method `haskey(obj::Object{String}, key::Symbol)`
- add respective tests