### PR TITLE
Add liftkey for numeric dict key types

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -338,6 +338,11 @@ StructUtils.lift(st::StructStyle, ::Type{T}, x::PtrString, tags) where {T} =
 StructUtils.lift(st::StructStyle, ::Type{T}, x::PtrString) where {T} =
     StructUtils.lift(st, T, convert(String, x))
 
+# liftkey for numeric dict key types to enable round-tripping Dict{Int,V}, Dict{Float64,V}, etc.
+# these correspond to the lowerkey definitions in write.jl that convert numeric keys to strings
+StructUtils.liftkey(::JSONStyle, ::Type{T}, x::AbstractString) where {T<:Integer} = Base.parse(T, x)
+StructUtils.liftkey(::JSONStyle, ::Type{T}, x::AbstractString) where {T<:AbstractFloat} = Base.parse(T, x)
+
 function StructUtils.lift(style::StructStyle, ::Type{T}, x::LazyValues) where {T<:AbstractArray{E,0}} where {E}
     m = T(undef)
     m[1], pos = StructUtils.lift(style, E, x)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -704,6 +704,13 @@ end
 
         StructUtils.liftkey(::JSON.JSONStyle, ::Type{Point}, x::String) = Point(parse(Int, split(x, "_")[1]), parse(Int, split(x, "_")[2]))
         @test JSON.parse("{\"1_2\":\"hi\"}", Dict{Point, String}) == Dict(Point(1, 2) => "hi")
+        # https://github.com/JuliaIO/JSON.jl/issues/422 - numeric dict key round-tripping
+        @test JSON.parse(JSON.json(Dict(1=>1)), Dict{Int,Int}) == Dict(1 => 1)
+        @test JSON.parse(JSON.json(Dict(1=>"a", 2=>"b")), Dict{Int,String}) == Dict(1 => "a", 2 => "b")
+        @test JSON.parse(JSON.json(Dict{Int,Int}()), Dict{Int,Int}) == Dict{Int,Int}()
+        @test JSON.parse("{\"1\":1,\"2\":2}", Dict{Int64,Int64}) == Dict(1 => 1, 2 => 2)
+        @test JSON.parse("{\"1.5\":1,\"2.5\":2}", Dict{Float64,Int}) == Dict(1.5 => 1, 2.5 => 2)
+        @test JSON.parse(JSON.json(Dict(1.5=>1, 2.5=>2)), Dict{Float64,Int}) == Dict(1.5 => 1, 2.5 => 2)
         # https://github.com/quinnj/JSON3.jl/issues/138
         @test JSON.parse("""{"num": 42}""", P) == P(42, "bar")
     end


### PR DESCRIPTION
## Summary

- Adds `liftkey` methods for `Integer` and `AbstractFloat` types to enable round-tripping `Dict{Int,V}`, `Dict{Float64,V}`, etc.
- These correspond to the existing `lowerkey` definitions in `write.jl` that convert numeric keys to strings when writing JSON

## Background

When writing a `Dict{Int,Int}` to JSON, numeric keys are correctly converted to strings via `lowerkey`:
```julia
JSON.json(Dict(1=>1))  # => "{\"1\":1}"
```

However, parsing this back fails because there was no corresponding `liftkey` to convert strings back to integers:
```julia
JSON.parse("{\"1\":1}", Dict{Int,Int})  # ERROR: MethodError
```

This PR adds the missing `liftkey` methods so that numeric-keyed dicts can now round-trip correctly.

Fixes #422

## Test plan

- [x] Added tests for `Dict{Int,Int}`, `Dict{Int,String}`, `Dict{Float64,Int}` round-tripping
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)