### PR TITLE
Fix misleading error message for lowerkey

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -251,7 +251,7 @@ end
 StructUtils.lowerkey(::JSONStyle, s::AbstractString) = s
 StructUtils.lowerkey(::JSONStyle, sym::Symbol) = String(sym)
 StructUtils.lowerkey(::JSONStyle, n::Union{Integer, Union{Float16, Float32, Float64}}) = string(n)
-StructUtils.lowerkey(::JSONStyle, x) = throw(ArgumentError("No key representation for $(typeof(x)). Define StructUtils.lowerkey(::$(typeof(x)))"))
+StructUtils.lowerkey(::JSONStyle, x) = throw(ArgumentError("No key representation for $(typeof(x)). Define StructUtils.lowerkey(::JSON.JSONStyle, ::$(typeof(x)))"))
 
 """
     JSON.json(x) -> String


### PR DESCRIPTION
## Summary
- Fixes the error message in `StructUtils.lowerkey` to suggest the correct method signature

The current error message tells users to define `StructUtils.lowerkey(::T)`, but the correct signature requires the `JSONStyle` argument: `StructUtils.lowerkey(::JSON.JSONStyle, ::T)`.

## Test plan
- [x] Existing tests pass
- [x] Verified the error message now shows the correct signature

Fixes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)