### PR TITLE
Support UUID and other stringlike types as keys

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -29,9 +29,11 @@ sizeguess(::Null) = 4
 sizeguess(::Omit) = 0
 sizeguess(_) = 512
 
+const StringLike = Union{Enum, AbstractChar, VersionNumber, Cstring, Cwstring, UUID, Dates.TimeType, Type, Logging.LogLevel}
+
 StructUtils.lower(::JSONStyle, ::Missing) = nothing
 StructUtils.lower(::JSONStyle, x::Symbol) = String(x)
-StructUtils.lower(::JSONStyle, x::Union{Enum, AbstractChar, VersionNumber, Cstring, Cwstring, UUID, Dates.TimeType, Type, Logging.LogLevel}) = string(x)
+StructUtils.lower(::JSONStyle, x::StringLike) = string(x)
 StructUtils.lower(::JSONStyle, x::Regex) = x.pattern
 StructUtils.lower(::JSONStyle, x::AbstractArray{<:Any,0}) = x[1]
 StructUtils.lower(::JSONStyle, x::AbstractArray{<:Any, N}) where {N} = (view(x, ntuple(_ -> :, N - 1)..., j) for j in axes(x, N))
@@ -250,9 +252,8 @@ end
 
 StructUtils.lowerkey(::JSONStyle, s::AbstractString) = s
 StructUtils.lowerkey(::JSONStyle, sym::Symbol) = String(sym)
-StructUtils.lowerkey(::JSONStyle, n::Union{Integer, Union{Float16, Float32, Float64}}) = string(n)
+StructUtils.lowerkey(::JSONStyle, s::Union{StringLike, Real}) = string(s)
 StructUtils.lowerkey(::JSONStyle, x) = throw(ArgumentError("No key representation for $(typeof(x)). Define StructUtils.lowerkey(::JSON.JSONStyle, ::$(typeof(x)))"))
-
 """
     JSON.json(x) -> String
     JSON.json(io, x)

--- a/test/json.jl
+++ b/test/json.jl
@@ -27,6 +27,8 @@ end
     dropped::Union{Nothing, JSON.Omit}
 end
 
+@enum JsonFruit Apple Orange
+
 @testset "JSON.json" begin
 
 @testset "Basics" begin
@@ -261,6 +263,18 @@ end
     @test JSON.json((a=1, b=nothing); omit_null=false) == "{\"a\":1,\"b\":null}"
     @test JSON.json((a=1, b=[]); omit_empty=true) == "{\"a\":1}"
     @test JSON.json((a=1, b=[]); omit_empty=false) == "{\"a\":1,\"b\":[]}"
+    @testset "All string-like types as keys" begin
+        date = Dates.DateTime(1970)
+        @test JSON.json([
+            UUID(0) => "uuid",
+            'c' => "char",
+            v"0.0.1" => "ver",
+            Apple => "Enum 1",
+            Orange => "Enum 2",
+            date => "date"
+        ]) == """{"00000000-0000-0000-0000-000000000000":"uuid","c":"char","0.0.1":"ver","Apple":"Enum 1","Orange":"Enum 2","1970-01-01T00:00:00":"date"}"""
+    end
+
     @testset "Sentinel overrides" begin
         @test JSON.json(JSON.Null()) == "null"
         @test_throws ArgumentError JSON.json(JSON.Omit())


### PR DESCRIPTION
This PR fixes the following error with UUID and other types:
```
julia> using JSON, UUIDs, Dates

julia> JSON.json(Dict(uuid4() => "str"))
ERROR: ArgumentError: No key representation for UUID. Define StructUtils.lowerkey(::JSON.JSONStyle, ::UUID)
Stacktrace:
 [1] lowerkey(::JSON.JSONWriteStyle, x::UUID)
   @ JSON ~/.julia/packages/JSON/eypqd/src/write.jl:254
 [2] applyeach
   @ ~/.julia/packages/StructUtils/RnTYI/src/StructUtils.jl:578 [inlined]
 [3] json!(buf::Vector{…}, pos::Int64, x::Dict{…}, opts::JSON.WriteOptions{…}, ancestor_stack::Vector{…}, io::Nothing, ind::Int64, depth::Int64, bufsize::Int64)
   @ JSON ~/.julia/packages/JSON/eypqd/src/write.jl:671
 [4] json! (repeats 3 times)
   @ ~/.julia/packages/JSON/eypqd/src/write.jl:612 [inlined]
 [5] json(x::Dict{UUID, String}; pretty::Bool, kw::@Kwargs{})
   @ JSON ~/.julia/packages/JSON/eypqd/src/write.jl:482
 [6] json(x::Dict{UUID, String})
   @ JSON ~/.julia/packages/JSON/eypqd/src/write.jl:475
 [7] top-level scope
   @ REPL[3]:1
Some type informatio
```
The same error happens with Char, VersionNumber and some other types which should work out of the box.
For `lowerkey` I also changed `Union{Float16, Float32, Float64}` to `Real`, but if there is a reason why only specific types were supported we can revert it.