### PR TITLE
Add sort_keys keyword for deterministic JSON output

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -434,7 +434,7 @@ function json end
     inline_limit::Int = 0
     float_style::Symbol = :shortest # :shortest, :fixed, :exp
     float_precision::Int = 1
-    sort_keys::Bool = false
+    sort_keys::Union{Bool, Nothing} = nothing
     bufsize::Int = 2^22 # 4MB default buffer size for IO flushing
     style::S = JSONWriteStyle()
 end
@@ -669,7 +669,8 @@ function json!(buf, pos, x, opts::WriteOptions, ancestor_stack::Union{Nothing, V
         wroteanyref = Ref(false)
         GC.@preserve ref wroteanyref begin
             c = WriteClosure{typeof(opts), al, typeof(x), typeof(io)}(buf, Base.unsafe_convert(Ptr{Int}, ref), Base.unsafe_convert(Ptr{Bool}, wroteanyref), local_ind, depth + 1, opts, ancestor_stack, io, bufsize)
-            if opts.sort_keys && !al && x isa AbstractDict
+            _sort_keys = opts.sort_keys === true || (opts.sort_keys === nothing && !al && x isa AbstractDict && !(x isa Object))
+            if _sort_keys && !al && x isa AbstractDict
                 sorted_keys = sort!(collect(keys(x)), by=k -> StructUtils.lowerkey(opts.style, k))
                 for k in sorted_keys
                     c(StructUtils.lowerkey(opts.style, k), StructUtils.lower(opts.style, x[k]))

--- a/test/json.jl
+++ b/test/json.jl
@@ -664,41 +664,47 @@ end
 end
 
 @testset "sort_keys" begin
-    # basic alphabetical sorting
-    @test JSON.json(Dict("c" => 3, "a" => 1, "b" => 2); sort_keys=true) == "{\"a\":1,\"b\":2,\"c\":3}"
+    # default (nothing): Dict keys are sorted, Object preserves insertion order
+    @test JSON.json(Dict("c" => 3, "a" => 1, "b" => 2)) == "{\"a\":1,\"b\":2,\"c\":3}"
+    obj = JSON.Object("c" => 3, "a" => 1, "b" => 2)
+    @test JSON.json(obj) == "{\"c\":3,\"a\":1,\"b\":2}"
 
-    # sort_keys=false is default (no sorting guarantee, but should not error)
-    @test JSON.json(Dict("a" => 1); sort_keys=false) == "{\"a\":1}"
+    # sort_keys=true: all AbstractDicts sorted, including Object
+    @test JSON.json(Dict("c" => 3, "a" => 1, "b" => 2); sort_keys=true) == "{\"a\":1,\"b\":2,\"c\":3}"
+    @test JSON.json(obj; sort_keys=true) == "{\"a\":1,\"b\":2,\"c\":3}"
+
+    # sort_keys=false: no sorting for any AbstractDict
+    @test JSON.json(obj; sort_keys=false) == "{\"c\":3,\"a\":1,\"b\":2}"
 
     # empty dict
+    @test JSON.json(Dict{String,Any}()) == "{}"
     @test JSON.json(Dict{String,Any}(); sort_keys=true) == "{}"
 
     # single key
-    @test JSON.json(Dict("only" => 42); sort_keys=true) == "{\"only\":42}"
+    @test JSON.json(Dict("only" => 42)) == "{\"only\":42}"
 
-    # nested dicts are sorted recursively
-    @test JSON.json(Dict("z" => Dict("b" => 2, "a" => 1), "a" => 3); sort_keys=true) == "{\"a\":3,\"z\":{\"a\":1,\"b\":2}}"
+    # nested dicts are sorted recursively by default
+    @test JSON.json(Dict("z" => Dict("b" => 2, "a" => 1), "a" => 3)) == "{\"a\":3,\"z\":{\"a\":1,\"b\":2}}"
 
     # arrays are not affected, but dicts inside arrays are sorted
-    @test JSON.json([Dict("b" => 2, "a" => 1), Dict("d" => 4, "c" => 3)]; sort_keys=true) == "[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]"
+    @test JSON.json([Dict("b" => 2, "a" => 1), Dict("d" => 4, "c" => 3)]) == "[{\"a\":1,\"b\":2},{\"c\":3,\"d\":4}]"
 
     # Symbol keys (lowered to strings via lowerkey, sorted as strings)
-    @test JSON.json(Dict(:zebra => 1, :apple => 2); sort_keys=true) == "{\"apple\":2,\"zebra\":1}"
+    @test JSON.json(Dict(:zebra => 1, :apple => 2)) == "{\"apple\":2,\"zebra\":1}"
 
     # Integer keys (lowered to strings, sorted lexicographically as strings)
-    @test JSON.json(Dict(3 => "c", 1 => "a", 2 => "b"); sort_keys=true) == "{\"1\":\"a\",\"2\":\"b\",\"3\":\"c\"}"
+    @test JSON.json(Dict(3 => "c", 1 => "a", 2 => "b")) == "{\"1\":\"a\",\"2\":\"b\",\"3\":\"c\"}"
 
-    # JSON.Object (preserves insertion order normally, but sort_keys overrides)
-    obj = JSON.Object("c" => 3, "a" => 1, "b" => 2)
-    @test JSON.json(obj; sort_keys=true) == "{\"a\":1,\"b\":2,\"c\":3}"
-    # without sort_keys, Object preserves insertion order
-    @test JSON.json(obj) == "{\"c\":3,\"a\":1,\"b\":2}"
+    # nested Object inside Dict: Dict sorted, Object preserves order (default)
+    @test JSON.json(Dict("z" => JSON.Object("b" => 2, "a" => 1), "a" => 3)) == "{\"a\":3,\"z\":{\"b\":2,\"a\":1}}"
+    # with sort_keys=true, both are sorted
+    @test JSON.json(Dict("z" => JSON.Object("b" => 2, "a" => 1), "a" => 3); sort_keys=true) == "{\"a\":3,\"z\":{\"a\":1,\"b\":2}}"
 
     # sort_keys + pretty printing
-    @test JSON.json(Dict("c" => 3, "a" => 1, "b" => 2); sort_keys=true, pretty=true) == "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+    @test JSON.json(Dict("c" => 3, "a" => 1, "b" => 2); pretty=true) == "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
 
     # sort_keys + omit_null
-    @test JSON.json(Dict("c" => nothing, "a" => 1, "b" => 2); sort_keys=true, omit_null=true) == "{\"a\":1,\"b\":2}"
+    @test JSON.json(Dict("c" => nothing, "a" => 1, "b" => 2); omit_null=true) == "{\"a\":1,\"b\":2}"
 
     # sort_keys does not affect structs (struct field order is deterministic)
     @test JSON.json(A(1, 2, 3, 4); sort_keys=true) == "{\"a\":1,\"b\":2,\"c\":3,\"d\":4}"
@@ -711,26 +717,26 @@ end
 
     # deeply nested mixed structures
     deep = Dict("z" => [Dict("b" => Dict("d" => 4, "c" => 3), "a" => 1)], "m" => 2)
-    @test JSON.json(deep; sort_keys=true) == "{\"m\":2,\"z\":[{\"a\":1,\"b\":{\"c\":3,\"d\":4}}]}"
+    @test JSON.json(deep) == "{\"m\":2,\"z\":[{\"a\":1,\"b\":{\"c\":3,\"d\":4}}]}"
 
     # IO path
     io = IOBuffer()
-    JSON.json(io, Dict("c" => 3, "a" => 1, "b" => 2); sort_keys=true)
+    JSON.json(io, Dict("c" => 3, "a" => 1, "b" => 2))
     @test String(take!(io)) == "{\"a\":1,\"b\":2,\"c\":3}"
 
     # file path
     fname = tempname()
-    JSON.json(fname, Dict("c" => 3, "a" => 1); sort_keys=true)
+    JSON.json(fname, Dict("c" => 3, "a" => 1))
     @test read(fname, String) == "{\"a\":1,\"c\":3}"
     rm(fname)
 
     # sort_keys + jsonlines (dicts inside array should be sorted)
-    @test JSON.json([Dict("b" => 2, "a" => 1), Dict("d" => 4, "c" => 3)]; sort_keys=true, jsonlines=true) == "{\"a\":1,\"b\":2}\n{\"c\":3,\"d\":4}\n"
+    @test JSON.json([Dict("b" => 2, "a" => 1), Dict("d" => 4, "c" => 3)]; jsonlines=true) == "{\"a\":1,\"b\":2}\n{\"c\":3,\"d\":4}\n"
 
     # sort_keys + buffered IO (small buffer forces flushes)
     io = IOBuffer()
     large = Dict(string(Char('a' + i)) => i for i in 0:25)
-    JSON.json(io, large; sort_keys=true, bufsize=64)
+    JSON.json(io, large; bufsize=64)
     result = String(take!(io))
     parsed_keys = [m.match for m in eachmatch(r"\"([a-z])\"", result)]
     @test parsed_keys == sort(parsed_keys)


### PR DESCRIPTION
## Summary

- Adds `sort_keys::Union{Bool, Nothing}=nothing` keyword argument to `JSON.json` / `JSON.print` for controlling dictionary key ordering
- **Default behavior (`nothing`)**: non-`Object` `AbstractDict` keys are sorted alphabetically; `JSON.Object` preserves insertion order
- `sort_keys=true`: all `AbstractDict` types sorted, including `Object`
- `sort_keys=false`: no sorting for any `AbstractDict`
- Sorts by the lowered string representation of keys (via `StructUtils.lowerkey`), so works correctly with `String`, `Symbol`, `Integer`, and custom key types
- Works recursively on nested dicts; composes with all existing options (`pretty`, `omit_null`, `omit_empty`, `jsonlines`, buffered IO, etc.)
- Struct and NamedTuple field order is unaffected (already deterministic)

This is a standard feature across JSON libraries: Python's `json.dumps(sort_keys=True)`, Go's `encoding/json` (always sorted), Rust's `serde_json` (sorted by default), Java Jackson's `ORDER_MAP_ENTRIES_BY_KEYS`, etc.

### Rationale for default sorting

Julia's `Dict` has non-deterministic iteration order that varies across versions, platforms, and runs. The default `sort_keys=nothing` follows Go and Rust's lead by sorting `Dict` output by default, which eliminates a class of bugs in snapshot testing, diffing, and caching. `JSON.Object` is exempted because it was specifically designed for insertion-order preservation — users who choose `Object` have explicitly opted into a particular key ordering.

### Usage

```julia
# Default: Dict sorted, Object preserves insertion order
JSON.json(Dict("c" => 3, "a" => 1))        # => {"a":1,"c":3}
JSON.json(JSON.Object("c" => 3, "a" => 1)) # => {"c":3,"a":1}

# Explicit: sort everything including Object
JSON.json(obj; sort_keys=true)

# Explicit: opt out of sorting entirely
JSON.json(dict; sort_keys=false)
```

### Implementation

Three small changes in `src/write.jl`:
1. Added `sort_keys::Union{Bool, Nothing} = nothing` field to `WriteOptions`
2. In `json!`, when sorting is active and the value is an `AbstractDict`, collect and sort keys by `lowerkey`, then iterate in sorted order
3. Propagated `sort_keys` through the jsonlines `WriteOptions` reconstruction

Closes #437

## Test plan

- [x] Default behavior: `Dict` sorted, `Object` preserves insertion order
- [x] `sort_keys=true`: all AbstractDicts sorted including `Object`
- [x] `sort_keys=false`: no sorting
- [x] Nested `Dict` inside `Object` and vice versa (mixed behavior)
- [x] Empty dict, single key dict
- [x] Nested dicts sorted recursively
- [x] Symbol and Integer key types
- [x] Composition with `pretty`, `omit_null`, `jsonlines`
- [x] Structs, NamedTuples, arrays unaffected
- [x] IO and file output paths
- [x] Buffered IO with small buffer
- [x] Deeply nested mixed structures
- [x] Full existing test suite passes (314 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)