### PR TITLE
[codex] Preserve ordered dict output by default

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -292,6 +292,11 @@ All methods accept the following keyword arguments:
   If `false` or `0`, the output will be compact.
   Note: Pretty printing is not supported when `jsonlines=true`.
 
+- `sort_keys::Union{Bool, Nothing}=nothing`: Controls whether dictionary keys are sorted before writing.
+  If `true`, keys for all `AbstractDict` objects are sorted by their lowered string representation.
+  If `false`, dictionary iteration order is preserved. If `nothing`, plain `Dict` keys are sorted
+  by default while other dictionary-like containers preserve their iteration order.
+
 - `inline_limit::Int=0`: For arrays shorter than this limit, pretty printing will be disabled (indentation set to 0).
 
 - `ninf::String="-Infinity"`: Custom string representation for negative infinity.
@@ -547,6 +552,8 @@ end
 
 checkkey(s) = s isa AbstractString || throw(ArgumentError("Value returned from `StructUtils.lowerkey` must be a string: $(typeof(s))"))
 
+_sort_keys_by_default(x) = x isa Dict
+
 function (f::WriteClosure{JS, arraylike, T, I})(key, val) where {JS, arraylike, T, I}
     track_ref = ismutabletype(typeof(val))
     is_circ_ref = track_ref && any(x -> x === val, f.ancestor_stack)
@@ -670,7 +677,7 @@ function json!(buf, pos, x, opts::WriteOptions, ancestor_stack::Union{Nothing, V
         wroteanyref = Ref(false)
         GC.@preserve ref wroteanyref begin
             c = WriteClosure{typeof(opts), al, typeof(x), typeof(io)}(buf, Base.unsafe_convert(Ptr{Int}, ref), Base.unsafe_convert(Ptr{Bool}, wroteanyref), local_ind, depth + 1, opts, ancestor_stack, io, bufsize)
-            _sort_keys = opts.sort_keys === true || (opts.sort_keys === nothing && !al && x isa AbstractDict && !(x isa Object))
+            _sort_keys = opts.sort_keys === true || (opts.sort_keys === nothing && !al && _sort_keys_by_default(x))
             if _sort_keys && !al && x isa AbstractDict
                 sorted_keys = sort!(collect(keys(x)), by=k -> StructUtils.lowerkey(opts.style, k))
                 for k in sorted_keys

--- a/test/json.jl
+++ b/test/json.jl
@@ -27,6 +27,19 @@ end
     dropped::Union{Nothing, JSON.Omit}
 end
 
+struct Issue447OrderedDict{K,V} <: AbstractDict{K,V}
+    entries::Vector{Pair{K,V}}
+end
+
+Base.length(d::Issue447OrderedDict) = length(d.entries)
+Base.iterate(d::Issue447OrderedDict, state=1) = state > length(d.entries) ? nothing : (d.entries[state], state + 1)
+function Base.getindex(d::Issue447OrderedDict, key)
+    for (k, v) in d
+        isequal(k, key) && return v
+    end
+    throw(KeyError(key))
+end
+
 @enum JsonFruit Apple Orange
 
 @testset "JSON.json" begin
@@ -678,17 +691,21 @@ end
 end
 
 @testset "sort_keys" begin
-    # default (nothing): Dict keys are sorted, Object preserves insertion order
+    # default (nothing): Dict keys are sorted, Object and other AbstractDicts preserve iteration order
     @test JSON.json(Dict("c" => 3, "a" => 1, "b" => 2)) == "{\"a\":1,\"b\":2,\"c\":3}"
     obj = JSON.Object("c" => 3, "a" => 1, "b" => 2)
     @test JSON.json(obj) == "{\"c\":3,\"a\":1,\"b\":2}"
+    ordered = Issue447OrderedDict([:b => 2, :a => 1])
+    @test JSON.json(ordered) == "{\"b\":2,\"a\":1}"
 
     # sort_keys=true: all AbstractDicts sorted, including Object
     @test JSON.json(Dict("c" => 3, "a" => 1, "b" => 2); sort_keys=true) == "{\"a\":1,\"b\":2,\"c\":3}"
     @test JSON.json(obj; sort_keys=true) == "{\"a\":1,\"b\":2,\"c\":3}"
+    @test JSON.json(ordered; sort_keys=true) == "{\"a\":1,\"b\":2}"
 
     # sort_keys=false: no sorting for any AbstractDict
     @test JSON.json(obj; sort_keys=false) == "{\"c\":3,\"a\":1,\"b\":2}"
+    @test JSON.json(ordered; sort_keys=false) == "{\"b\":2,\"a\":1}"
 
     # empty dict
     @test JSON.json(Dict{String,Any}()) == "{}"


### PR DESCRIPTION
## Summary

- Limit default `sort_keys=nothing` behavior to plain `Dict` values.
- Preserve iteration order for other `AbstractDict` implementations, including `OrderedDict`-style containers.
- Keep explicit `sort_keys=true` behavior sorting all `AbstractDict` values.

## Root Cause

#442 made the default writer sort every non-`JSON.Object` `AbstractDict`. That improved deterministic output for unordered `Dict`, but it also changed the semantics of ordered dictionary implementations whose iteration order is meaningful.

## Validation

- Reproduced JSON 1.4.0 vs 1.5.0 behavior with `OrderedCollections.OrderedDict`.
- Verified this branch restores insertion-order output for `OrderedDict` while preserving `sort_keys=true`.
- Ran `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`.

Fixes #447.