### PR TITLE
fix(parse): forward type predicates to inner style

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -171,6 +171,11 @@ nullvalue(st::JSONReadStyle) = st.null
 StructUtils.fieldtagkey(::JSONStyle) = :json
 StructUtils.defaultstate(st::JSONReadStyle) = StructUtils.defaultstate(st.style)
 
+# forward StructUtils API to the inner style so user-provided JSONStyle dispatches are honored
+StructUtils.dictlike(st::JSONReadStyle, ::Type{T}) where {T} = StructUtils.dictlike(st.style, T)
+StructUtils.arraylike(st::JSONReadStyle, ::Type{T}) where {T} = StructUtils.arraylike(st.style, T)
+StructUtils.nulllike(st::JSONReadStyle, ::Type{T}) where {T} = StructUtils.nulllike(st.style, T)
+
 function jsonreadstyle(::Type{T}, ::Type{O}, null, style::StructStyle, unknown_fields::Symbol) where {T,O}
     ignore_unknown_fields =
         unknown_fields === :ignore ? true :

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -227,6 +227,15 @@ end
     any::Any &(choosetype=x -> x.type[] == "int" ? @NamedTuple{type::String, value::Int} : x.type[] == "float" ? @NamedTuple{type::String, value::Float64} : @NamedTuple{type::String, value::String},)
 end
 
+# https://github.com/JuliaIO/JSON.jl/issues/453 - custom JSONStyle dictlike dispatch
+@kwdef struct DictlikeViaCustomStyle
+    vals::Dict{String,Int} = Dict{String,Int}()
+end
+Base.keytype(::DictlikeViaCustomStyle) = String
+Base.valtype(::DictlikeViaCustomStyle) = Int
+StructUtils.addkeyval!(a::DictlikeViaCustomStyle, k, v) = StructUtils.addkeyval!(a.vals, k, v)
+StructUtils.dictlike(::CustomJSONStyle, ::Type{DictlikeViaCustomStyle}) = true
+
 @testset "JSON.parse" begin
     @testset "errors" begin
         # Unexpected character in array
@@ -765,6 +774,10 @@ end
     JSON.lift(::CustomJSONStyle, ::Type{Rational}, x) = Rational(x.num[], x.den[])
     @test JSON.parse("{\"num\": 1,\"den\":3}", Rational; style=CustomJSONStyle()) == 1//3
     @test JSON.parse("{\"num\": 1,\"den\":3}", Rational; style=CustomJSONStyle(), unknown_fields=:error) == 1//3
+    # https://github.com/JuliaIO/JSON.jl/issues/453 - dictlike dispatch on custom JSONStyle must reach user method
+    let res = JSON.parse("""{"a": 1, "b": 2}""", DictlikeViaCustomStyle; style=CustomJSONStyle())
+        @test res.vals == Dict("a" => 1, "b" => 2)
+    end
     @test isequal(JSON.parse("{\"num\": 1,\"den\":null}", @NamedTuple{num::Int, den::Union{Int, Missing}}; null=missing, style=StructUtils.DefaultStyle()), (num=1, den=missing))
     # choosetype field tag on Any struct field
     @test JSON.parse("{\"id\":1,\"any\":{\"type\":\"int\",\"value\":10}}", Q) == Q(1, (type="int", value=10))


### PR DESCRIPTION
## Summary
- Forward `dictlike`, `arraylike`, and `nulllike` from `JSONReadStyle` to its inner `st.style` so user-defined dispatches on a custom `JSONStyle` are honored during parsing.

## Why
In v1.5.1, `JSONReadStyle{O,T,S}` was changed to wrap the user-provided style to carry `null`/`dicttype`/`unknown_fields` configuration through. But `StructUtils.make()` dispatches on the wrapping `JSONReadStyle`, so a user's `dictlike(::CustomJSONStyle, ::Type{A}) = true` never fired and `make` fell through to `makestruct` instead of `makedict`. This broke the deserialization pattern that worked in v1.5.0, where the user's style was passed through directly.

Forwarding only the type-routing predicates (`dictlike`/`arraylike`/`nulllike`) was chosen deliberately:
- `noarg`/`kwarg`/`structlike`/`fieldtags`/`fielddefaults` are set via macros at the `::StructStyle` level, which already match through `JSONReadStyle`.
- Other `JSONStyle`-level defaults are inherited by any `<: JSONStyle` user style.
- Forwarding the rest would create dispatch ambiguities with existing `(::JSONStyle, ::Type{<:NamedTuple})` and macro-generated `(::StructStyle, ::Type{<:T})` methods.

Closes #453

## Test plan
- [x] Added regression test reproducing the exact issue example
- [x] Existing test suite passes (`Pkg.test()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)