### PR TITLE
fix(parse): default bare JSON.Object keys to String

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -167,6 +167,8 @@ objecttype(::JSONReadStyle{OT}) where {OT} = OT
 nullvalue(::StructStyle) = nothing
 nullvalue(st::JSONReadStyle) = st.null
 
+StructUtils.initialize(::JSONReadStyle, ::Type{Object}, source) = DEFAULT_OBJECT_TYPE()
+
 # this allows struct fields to specify tags under the json key specifically to override JSON behavior
 StructUtils.fieldtagkey(::JSONStyle) = :json
 StructUtils.defaultstate(st::JSONReadStyle) = StructUtils.defaultstate(st.style)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -303,6 +303,9 @@ StructUtils.dictlike(::CustomJSONStyle, ::Type{DictlikeViaCustomStyle}) = true
     @test !isempty(x) && x["a"] == 1 && typeof(x) == JSON.Object{String, Any}
     x = JSON.parse("{\"a\": 1, \"b\": null, \"c\": true, \"d\": false, \"e\": \"\", \"f\": [], \"g\": {}}")
     @test !isempty(x) && x["a"] == 1 && x["b"] === nothing && x["c"] === true && x["d"] === false && x["e"] == "" && x["f"] == Any[] && x["g"] == JSON.Object{String, Any}()
+    # https://github.com/JuliaIO/JSON.jl/issues/456
+    x = JSON.parse("{\"a\": 1}", JSON.Object)
+    @test x isa JSON.Object{String, Any} && x["a"] == 1
     # custom dicttype
     x = JSON.parse("{\"a\": 1, \"b\": null, \"c\": true, \"d\": false, \"e\": \"\", \"f\": [], \"g\": {}}"; dicttype=Dict{String, Any})
     # test that x isa Dict and nested x.g is also a Dict


### PR DESCRIPTION
## Summary
- make JSON.parse(json, JSON.Object) materialize JSON.Object{String, Any}
- add a regression test for issue #456

## Testing
- julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'

Fixes #456