### PR TITLE
feat(write): serialize complex numbers

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -35,6 +35,7 @@ StructUtils.lower(::JSONStyle, ::Missing) = nothing
 StructUtils.lower(::JSONStyle, x::Symbol) = String(x)
 StructUtils.lower(::JSONStyle, x::StringLike) = string(x)
 StructUtils.lower(::JSONStyle, x::Regex) = x.pattern
+StructUtils.lower(::JSONStyle, x::Complex) = (re=real(x), im=imag(x))
 StructUtils.lower(::JSONStyle, x::AbstractArray{<:Any,0}) = x[1]
 StructUtils.lower(::JSONStyle, x::AbstractArray{<:Any, N}) where {N} = (view(x, ntuple(_ -> :, N - 1)..., j) for j in axes(x, N))
 StructUtils.lower(::JSONStyle, x::AbstractVector) = x

--- a/test/json.jl
+++ b/test/json.jl
@@ -244,6 +244,9 @@ end
     @test_throws MethodError JSON.json(CustomNumber(3.14))
     JSON.tostring(x::CustomNumber) = string(x.x)
     @test JSON.json(CustomNumber(3.14)) == "3.14"
+    # https://github.com/JuliaIO/JSON.jl/issues/440
+    @test JSON.json(1 + 2im) == "{\"re\":1,\"im\":2}"
+    @test JSON.parse(JSON.json(1.0 + 2.0im), ComplexF64) == 1.0 + 2.0im
     # jsonlines output
     @test JSON.json([1, 2, 3]; jsonlines=true) == "1\n2\n3\n"
     # jsonlines output with pretty not allowed


### PR DESCRIPTION
## Summary
- serialize Complex values as objects with re/im fields
- add a Complex write/read round-trip regression test

## Testing
- julia --project=. -e 'using Pkg; Pkg.test(; coverage=false)'

Fixes #440