### PR TITLE
chore(release): bump version to 1.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.5.2"
+version = "1.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
## Summary
- Bump JSON.jl from 1.5.2 to 1.6.0 for the next release.
- Includes the merged #457 parser fix and #459 Complex serialization feature.
- Intentionally excludes #458; that PR remains draft/open and unmerged per maintainer direction.

## Verification
- `git diff --check`
- Registry latest confirmed as 1.5.2 before bump.