### PR TITLE
Mark user-facing methods `public`

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -9,6 +9,20 @@ using PrecompileTools, Parsers, StructUtils
 import StructUtils: @noarg, @kwarg, @defaults, @tags, @choosetype, @nonstruct, lower, lift
 export JSONText, StructUtils, @noarg, @kwarg, @defaults, @tags, @choosetype, @nonstruct, @omit_null, @omit_empty
 
+# Mark documented API as `public` on Julia versions that support it (>= 1.11).
+# Wrapped in `eval(Expr(...))` because `public` is a parse error on older versions.
+@static if VERSION >= v"1.11"
+    eval(Expr(:public,
+        :parse, :parse!, :parsefile, :parsefile!,
+        :lazy, :lazyfile, :LazyValue,
+        :isvalidjson,
+        :json, :print,
+        :lower, :lift,
+        :omit_null, :omit_empty,
+        :Object, :Null, :Omit, :JSONStyle,
+    ))
+end
+
 @enum Error InvalidJSON UnexpectedEOF ExpectedOpeningObjectChar ExpectedOpeningQuoteChar ExpectedOpeningArrayChar ExpectedClosingArrayChar ExpectedComma ExpectedColon ExpectedNewline InvalidChar InvalidNumber InvalidUTF16
 
 @noinline function invalid(error, buf, pos::Int, T)


### PR DESCRIPTION
`public` was added in Julia 1.11 and the ExplicitImports package allows one to check whether a package only accesses public names in its dependencies. I've been finding this a useful addition to many of my packages. The help string now shows
```
help?> JSON.parsefile
  │ Warning
  │
  │  The following bindings may be internal; they may change or be removed in future versions:
  │
  │    •  JSON.parsefile

  See parse.
```
This should silence the warning and allow ExplicitImports tests in other packages that use JSON to pass.