### PR TITLE
fix(parse): honor custom style structlike

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -177,6 +177,12 @@ StructUtils.defaultstate(st::JSONReadStyle) = StructUtils.defaultstate(st.style)
 StructUtils.dictlike(st::JSONReadStyle, ::Type{T}) where {T} = StructUtils.dictlike(st.style, T)
 StructUtils.arraylike(st::JSONReadStyle, ::Type{T}) where {T} = StructUtils.arraylike(st.style, T)
 StructUtils.nulllike(st::JSONReadStyle, ::Type{T}) where {T} = StructUtils.nulllike(st.style, T)
+# Keep structlike forwarding specific to custom JSONStyle wrappers so type-level StructStyle
+# specializations (for example @nonstruct types) continue to dispatch without ambiguity.
+StructUtils.structlike(st::JSONReadStyle{O,N,S}, ::Type{T}) where {O,N,S<:JSONStyle,T} =
+    StructUtils.structlike(st.style, T)
+StructUtils.structlike(st::JSONReadStyle{O,N,S}, ::Type{T}) where {O,N,S<:JSONStyle,T<:NamedTuple} =
+    StructUtils.structlike(st.style, T)
 
 function jsonreadstyle(::Type{T}, ::Type{O}, null, style::StructStyle, unknown_fields::Symbol) where {T,O}
     ignore_unknown_fields =

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1,6 +1,7 @@
 using JSON, StructUtils, UUIDs, Dates, Test
 
 struct CustomJSONStyle <: JSON.JSONStyle end
+struct RefValueStyle <: JSON.JSONStyle end
 
 struct A
     a::Int
@@ -235,6 +236,10 @@ Base.keytype(::DictlikeViaCustomStyle) = String
 Base.valtype(::DictlikeViaCustomStyle) = Int
 StructUtils.addkeyval!(a::DictlikeViaCustomStyle, k, v) = StructUtils.addkeyval!(a.vals, k, v)
 StructUtils.dictlike(::CustomJSONStyle, ::Type{DictlikeViaCustomStyle}) = true
+
+StructUtils.structlike(::RefValueStyle, ::Type{Base.RefValue{Int}}) = false
+StructUtils.lower(::RefValueStyle, x::Base.RefValue{Int}) = x[]
+StructUtils.lift(::RefValueStyle, ::Type{Base.RefValue{Int}}, x::Integer) = Ref{Int}(x), nothing
 
 @testset "JSON.parse" begin
     @testset "errors" begin
@@ -780,6 +785,11 @@ StructUtils.dictlike(::CustomJSONStyle, ::Type{DictlikeViaCustomStyle}) = true
     # https://github.com/JuliaIO/JSON.jl/issues/453 - dictlike dispatch on custom JSONStyle must reach user method
     let res = JSON.parse("""{"a": 1, "b": 2}""", DictlikeViaCustomStyle; style=CustomJSONStyle())
         @test res.vals == Dict("a" => 1, "b" => 2)
+    end
+    # https://github.com/JuliaIO/JSON.jl/issues/462 - structlike dispatch on custom JSONStyle must reach user method
+    let json = JSON.json(Ref{Int}(1); style=RefValueStyle())
+        @test json == "1"
+        @test JSON.parse(json, Base.RefValue{Int}; style=RefValueStyle())[] == 1
     end
     @test isequal(JSON.parse("{\"num\": 1,\"den\":null}", @NamedTuple{num::Int, den::Union{Int, Missing}}; null=missing, style=StructUtils.DefaultStyle()), (num=1, den=missing))
     # choosetype field tag on Any struct field


### PR DESCRIPTION
## Summary
- forward `structlike` checks from `JSONReadStyle` to wrapped custom `JSONStyle`s
- add an issue #462 regression covering `Base.RefValue{Int}` round-tripping through a custom style

## Testing
- `git diff --check`
- focused issue #462 repro on Julia 1.12.5
- `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`

Fixes #462