### PR TITLE
Fix PtrString hash compatibility

### DIFF
--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -445,9 +445,12 @@ function Base.convert(::Type{T}, x::PtrString) where {T <: Enum}
 end
 
 Base.:(==)(x::PtrString, y::AbstractString) = x.len == sizeof(y) && ccall(:memcmp, Cint, (Ptr{UInt8}, Ptr{UInt8}, Csize_t), x.ptr, pointer(y), x.len) == 0
+Base.:(==)(x::AbstractString, y::PtrString) = y == x
 Base.:(==)(x::PtrString, y::PtrString) = x.len == y.len && ccall(:memcmp, Cint, (Ptr{UInt8}, Ptr{UInt8}, Csize_t), x.ptr, y.ptr, x.len) == 0
 Base.isequal(x::PtrString, y::AbstractString) = x == y
+Base.isequal(x::AbstractString, y::PtrString) = y == x
 Base.isequal(x::PtrString, y::PtrString) = x == y
+Base.hash(x::PtrString, h::UInt) = hash(unsafe_string(x.ptr, x.len), h)
 StructUtils.keyeq(x::PtrString, y::AbstractString) = x == y
 StructUtils.keyeq(x::PtrString, y::String) = x == y
 StructUtils.keyeq(x::PtrString, y::Symbol) = convert(Symbol, x) == y

--- a/test/lazy.jl
+++ b/test/lazy.jl
@@ -71,6 +71,16 @@ end
     x = JSON.lazy("{}"; allownan=true)
     @test_throws ArgumentError JSON.parsenumber(x)
 
+    str = JSON.lazy("\"alpha\"")
+    key, _ = JSON.parsestring(str)
+    @test key == "alpha"
+    @test "alpha" == key
+    @test isequal(key, "alpha")
+    @test isequal("alpha", key)
+    @test hash(key) == hash("alpha")
+    @test haskey(Dict{Any,Int}(key => 1), "alpha")
+    @test "alpha" in Set{Any}([key])
+
     # lazy indexing selection support
     # examples from https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html
     json = """


### PR DESCRIPTION
## Summary
- Add reverse `AbstractString`/`PtrString` equality so comparisons are symmetric.
- Add `Base.hash(::PtrString, ::UInt)` so equal `PtrString` and `String` values hash identically.
- Cover the regression with lazy parser tests for equality, hashing, `Dict`, and `Set` lookup.

## Root Cause
`PtrString` defined `==`/`isequal` against `AbstractString` but did not define a matching `hash` method. Hash-table lookup also exposed that the equality methods only handled `PtrString` on the left-hand side.

## Validation
- `tmpenv=$(mktemp -d); julia --startup-file=no --project="$tmpenv" -e 'using Pkg; Pkg.develop(path=pwd()); using JSON, Test; include("test/lazy.jl")'`
- `tmpenv=$(mktemp -d); julia --startup-file=no --project="$tmpenv" -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.test("JSON")'`

Fixes #467

Co-authored by Codex
