### PR TITLE
Don't throw BoundsError when reporting UnexpectedEOF

### DIFF
--- a/src/JSON.jl
+++ b/src/JSON.jl
@@ -50,10 +50,15 @@ end
 @noinline function _invalid(error, buf, pos::Int, typename::String)
     # compute which line the error falls on by counting “\n” bytes up to pos
     cus = buf isa AbstractString ? codeunits(buf) : buf
-    line_no = count(b -> b == UInt8('\n'), view(cus, 1:pos)) + 1
+    # `pos` can point one byte past the end: UnexpectedEOF is reported at the
+    # position we wanted to read, so every input ending mid-token lands here
+    # with pos == sizeof(cus) + 1. Clamp before slicing, or building the error
+    # message throws BoundsError instead of the ArgumentError we mean to raise.
+    n = sizeof(cus)
+    line_no = count(b -> b == UInt8('\n'), view(cus, 1:min(pos, n))) + 1
 
-    li = pos > 20 ? pos - 9 : 1
-    ri = min(sizeof(cus), pos + 20)
+    li = pos > 20 ? min(pos - 9, n) : 1
+    ri = min(n, pos + 20)
     snippet_bytes = cus[li:ri]
     snippet_pos = pos - li + 1
     snippet = String(copy(snippet_bytes))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -276,6 +276,35 @@ JSON.lift(::DateMaterializedObjectStyle, ::Type{Date}, x::JSON.Object) = Date(x[
         @test x.url == "http://www.example.com/#\\\ud8000\\好"
     end # @testset "errors"
 
+    @testset "truncated input reports UnexpectedEOF" begin
+        # UnexpectedEOF is raised at the byte we wanted to read, i.e. one past
+        # the end, so building the error message used to slice out of bounds and
+        # throw BoundsError from the error path itself.
+        for str in ("{", "[", "[1", "[1,", "\"a", "{\"a\"", "{\"a\":", "{\"a\":1,",
+                    " ", "\n", "\t", "{\"a\":[1,2", "-")
+            @test_throws ArgumentError JSON.parse(str)
+        end
+        # Same for the typed and lazy entry points.
+        @test_throws ArgumentError JSON.parse("{\"a\":", @NamedTuple{a::Int})
+        @test_throws ArgumentError JSON.lazy("{\"a\":")[]
+        # ...and when the buffer is bytes rather than a string.
+        @test_throws ArgumentError JSON.parse(Vector{UInt8}("{\"a\":"))
+
+        # The message still carries a correct position, line number and snippet.
+        err = try
+            JSON.parse("{\n  \"a\": 1,\n  \"b\":")
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        msg = err.msg
+        @test occursin("UnexpectedEOF", msg)
+        @test occursin("byte position 18", msg) || occursin("byte position 19", msg)
+        @test occursin("line 3", msg)
+        @test occursin("<EOF>", msg)
+    end # @testset "truncated input reports UnexpectedEOF"
+
     # JSON.jl pre-1.0 compat
     x = JSON.parse("{}")
     @test isempty(x) && typeof(x) == JSON.Object{String, Any}


### PR DESCRIPTION
## The bug

Any JSON input that ends mid-token throws `BoundsError` from inside the error-reporting path, instead of the `ArgumentError` the parser means to raise:

```julia
julia> using JSON

julia> JSON.parse("{")
ERROR: BoundsError: attempt to access 1-element Base.CodeUnits{UInt8, String} at index [1:2]
Stacktrace:
 [3] view @ ./subarray.jl:214 [inlined]
 [4] _invalid(error::JSON.Error, buf::String, pos::Int64, typename::String) @ JSON src/JSON.jl:53
```

Same for `JSON.parse("[")`, `JSON.parse("[1")`, `JSON.parse("\"a")`, `JSON.parse("{\"a\":")`, and whitespace-only buffers such as `" "` and `"\n"`. It reaches the typed, lazy and byte-buffer entry points alike (`JSON.parse(str, T)`, `JSON.lazy(str)[]`, `JSON.parse(Vector{UInt8}(...))`).

## Cause

`_invalid` computes the error's line number as

```julia
line_no = count(b -> b == UInt8('\n'), view(cus, 1:pos)) + 1
```

without clamping `pos` to the buffer, while the snippet slice two lines below already clamps (`ri = min(sizeof(cus), pos + 20)`). `UnexpectedEOF` is reported at the byte the parser wanted to read, so truncated input always arrives here with `pos == sizeof(cus) + 1` and the `view` is out of bounds.

Inputs that stop exactly *at* the last byte (e.g. `JSON.parse("{\"cmd\":\"echo hi\\")`) report `pos == sizeof(cus)` and correctly raise `ArgumentError`, which is why this went unnoticed — the existing incomplete-escape test in `test/parse.jl` takes that path.

## Fix

Clamp the line-count range, and the snippet's left index for good measure. The message is otherwise unchanged — position, line number, snippet and caret still point at the truncation:

```julia
julia> JSON.parse("{\n  \"a\": 1,\n  \"b\":")
ERROR: ArgumentError: invalid JSON at byte position 19 (line 3) parsing type object: UnexpectedEOF
{   "a": 1,   "b": <EOF>
                   ^
```

## Tests

New `@testset "truncated input reports UnexpectedEOF"` in `test/parse.jl` covering 13 truncation shapes across the string, typed, lazy and byte-buffer entry points, plus assertions that the message still carries the right byte position, line number and `<EOF>` marker. Verified these fail on unfixed code (all `BoundsError`) and pass with the fix. Full suite green via `Pkg.test()`.

## How it turned up

Fuzzing tool-argument parsing in a downstream agent framework: a truncated LLM-produced arguments string surfaced as `BoundsError` rather than the `ArgumentError` the caller catches to report malformed input.