### PR TITLE
FIX InexactError when using allownan with typemax(Int)

### DIFF
--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -539,16 +539,16 @@ macro check_special(special, value)
         b = getbyte(buf, pos)
         bytes = codeunits($special)
         i = 1
-        while b == @inbounds(bytes[i])
+        while i <= length(bytes) && b == @inbounds(bytes[i])
             pos += 1
             i += 1
-            i > length(bytes) && break
-            if pos > len
-                error = UnexpectedEOF
-                @goto invalid
+            if i <= length(bytes)
+                if pos > len
+                    error = UnexpectedEOF
+                    @goto invalid
+                end
+                b = getbyte(buf, pos)
             end
-            b = getbyte(buf, pos)
-            i += 1
         end
         if i > length(bytes)
             return NumberResult($value), pos

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -589,84 +589,103 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
     isneg = isfloat = overflow = false
 
     if opts.allownan
-        @check_special(opts.nan, NaN)
-        @check_special(opts.inf, Inf)
-        @check_special(opts.ninf, -Inf)
-        # reset after any failed partial match (see note above)
-        pos = startpos
-        b = getbyte(buf, pos)
-    end
-
-    val = Int64(0)
-    isneg = b == UInt8('-')
-    if isneg || b == UInt8('+') # spec doesn't allow leading +, but we do
-        pos += 1
-        if pos > len
-            error = UnexpectedEOF
-            @goto invalid
-        end
-        b = getbyte(buf, pos)
-    end
-    # Parse integer part, check for leading zeros (invalid JSON)
-    if b == UInt8('0')
-        pos += 1
-        if pos <= len
-            b = getbyte(buf, pos)
-            if UInt8('0') <= b <= UInt8('9')
-                error = InvalidNumber
+        # If this doesn't start like an integer, let Parsers handle
+        # NaN/Inf/-Inf and the configured special values.
+        if b == UInt8('-') || b == UInt8('+')
+            if pos == len
+                error = UnexpectedEOF
                 @goto invalid
             end
+            b = getbyte(buf, pos + 1)
+            isfloat = !(UInt8('0') <= b <= UInt8('9'))
+        else
+            isfloat = !(UInt8('0') <= b <= UInt8('9'))
         end
-    elseif UInt8('1') <= b <= UInt8('9')
-        while UInt8('0') <= b <= UInt8('9')
-            digit = Int64(b - UInt8('0'))
-            if val > INT64_OVERFLOW_VAL || (val == INT64_OVERFLOW_VAL && digit > INT64_OVERFLOW_DIGIT)
-                overflow = true
-                break
-            end
-            val = Int64(10) * val + digit
-            pos += 1
-            pos > len && break
-            b = getbyte(buf, pos)
-        end
-        if overflow
-            bval = BigInt(val)
-            while UInt8('0') <= b <= UInt8('9')
-                digit = BigInt(b - UInt8('0'))
-                bval = BigInt(10) * bval + digit
-                pos += 1
-                pos > len && break
-                b = getbyte(buf, pos)
-            end
-        end
-    elseif opts.allownan
-        # not a digit/sign start and no special token matched above -
-        # let Parsers' own float lexer take a shot (handles any
-        # remaining native spellings it knows about)
-        isfloat = true
-    else
-        error = InvalidNumber
-        @goto invalid
     end
-    # Check for decimal or exponent
-    if !isfloat && (b == UInt8('.') || b == UInt8('e') || b == UInt8('E'))
-        isfloat = true
-        if b == UInt8('.')
+
+    if !isfloat
+        val = Int64(0)
+        b = getbyte(buf, pos)
+        isneg = b == UInt8('-')
+
+        if isneg || b == UInt8('+') # spec doesn't allow leading +, but we do
             pos += 1
             if pos > len
                 error = UnexpectedEOF
                 @goto invalid
             end
             b = getbyte(buf, pos)
-            if !(UInt8('0') <= b <= UInt8('9'))
-                error = InvalidNumber
-                @goto invalid
+        end
+
+        # Parse integer part, check for leading zeros (invalid JSON)
+        if b == UInt8('0')
+            pos += 1
+            if pos <= len
+                b = getbyte(buf, pos)
+                if UInt8('0') <= b <= UInt8('9')
+                    error = InvalidNumber
+                    @goto invalid
+                end
+            end
+        elseif UInt8('1') <= b <= UInt8('9')
+            while UInt8('0') <= b <= UInt8('9')
+                digit = Int64(b - UInt8('0'))
+                if val > INT64_OVERFLOW_VAL ||
+                   (val == INT64_OVERFLOW_VAL && digit > INT64_OVERFLOW_DIGIT)
+                    overflow = true
+                    break
+                end
+                val = Int64(10) * val + digit
+                pos += 1
+                pos > len && break
+                b = getbyte(buf, pos)
+            end
+
+            if overflow
+                bval = BigInt(val)
+                while UInt8('0') <= b <= UInt8('9')
+                    digit = BigInt(b - UInt8('0'))
+                    bval = BigInt(10) * bval + digit
+                    pos += 1
+                    pos > len && break
+                    b = getbyte(buf, pos)
+                end
+            end
+        else
+            error = InvalidNumber
+            @goto invalid
+        end
+
+        # Check for decimal or exponent
+        if b == UInt8('.') || b == UInt8('e') || b == UInt8('E')
+            isfloat = true
+
+            # in strict JSON spec, we need at least one digit after the decimal
+            if b == UInt8('.')
+                pos += 1
+                if pos > len
+                    error = UnexpectedEOF
+                    @goto invalid
+                end
+                b = getbyte(buf, pos)
+                if !(UInt8('0') <= b <= UInt8('9'))
+                    error = InvalidNumber
+                    @goto invalid
+                end
             end
         end
     end
 
     if isfloat
+        if opts.allownan
+            # check for NaN, Inf, -Inf
+            @check_special(opts.nan, NaN)
+            @check_special(opts.inf, Inf)
+            @check_special(opts.ninf, -Inf)
+        end
+
         res = Parsers.xparse2(Float64, buf, startpos, len)
+
         if !opts.allownan && Parsers.specialvalue(res.code)
             # if we overflowed, then let's try BigFloat
             bres = Parsers.xparse2(BigFloat, buf, startpos, len)
@@ -674,10 +693,12 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
                 return NumberResult(bres.val), startpos + Int(bres.tlen)
             end
         end
+
         if Parsers.invalid(res.code)
             error = InvalidNumber
             @goto invalid
         end
+
         return NumberResult(res.val), Int(startpos + res.tlen)
     else
         if overflow

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -539,16 +539,16 @@ macro check_special(special, value)
         b = getbyte(buf, pos)
         bytes = codeunits($special)
         i = 1
-        while i <= length(bytes) && b == @inbounds(bytes[i])
+        while b == @inbounds(bytes[i])
             pos += 1
             i += 1
-            if i <= length(bytes)
-                if pos > len
-                    error = UnexpectedEOF
-                    @goto invalid
-                end
-                b = getbyte(buf, pos)
+            i > length(bytes) && break
+            if pos > len
+                error = UnexpectedEOF
+                @goto invalid
             end
+            b = getbyte(buf, pos)
+            i += 1
         end
         if i > length(bytes)
             return NumberResult($value), pos

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -587,78 +587,85 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
     b = getbyte(buf, pos)
     startpos = pos
     isneg = isfloat = overflow = false
-    if !opts.allownan
-        val = Int64(0)
-        isneg = b == UInt8('-')
-        if isneg || b == UInt8('+') # spec doesn't allow leading +, but we do
+
+    if opts.allownan
+        @check_special(opts.nan, NaN)
+        @check_special(opts.inf, Inf)
+        @check_special(opts.ninf, -Inf)
+        # reset after any failed partial match (see note above)
+        pos = startpos
+        b = getbyte(buf, pos)
+    end
+
+    val = Int64(0)
+    isneg = b == UInt8('-')
+    if isneg || b == UInt8('+') # spec doesn't allow leading +, but we do
+        pos += 1
+        if pos > len
+            error = UnexpectedEOF
+            @goto invalid
+        end
+        b = getbyte(buf, pos)
+    end
+    # Parse integer part, check for leading zeros (invalid JSON)
+    if b == UInt8('0')
+        pos += 1
+        if pos <= len
+            b = getbyte(buf, pos)
+            if UInt8('0') <= b <= UInt8('9')
+                error = InvalidNumber
+                @goto invalid
+            end
+        end
+    elseif UInt8('1') <= b <= UInt8('9')
+        while UInt8('0') <= b <= UInt8('9')
+            digit = Int64(b - UInt8('0'))
+            if val > INT64_OVERFLOW_VAL || (val == INT64_OVERFLOW_VAL && digit > INT64_OVERFLOW_DIGIT)
+                overflow = true
+                break
+            end
+            val = Int64(10) * val + digit
+            pos += 1
+            pos > len && break
+            b = getbyte(buf, pos)
+        end
+        if overflow
+            bval = BigInt(val)
+            while UInt8('0') <= b <= UInt8('9')
+                digit = BigInt(b - UInt8('0'))
+                bval = BigInt(10) * bval + digit
+                pos += 1
+                pos > len && break
+                b = getbyte(buf, pos)
+            end
+        end
+    elseif opts.allownan
+        # not a digit/sign start and no special token matched above -
+        # let Parsers' own float lexer take a shot (handles any
+        # remaining native spellings it knows about)
+        isfloat = true
+    else
+        error = InvalidNumber
+        @goto invalid
+    end
+    # Check for decimal or exponent
+    if !isfloat && (b == UInt8('.') || b == UInt8('e') || b == UInt8('E'))
+        isfloat = true
+        if b == UInt8('.')
             pos += 1
             if pos > len
                 error = UnexpectedEOF
                 @goto invalid
             end
             b = getbyte(buf, pos)
-        end
-        # Parse integer part, check for leading zeros (invalid JSON)
-        if b == UInt8('0')
-            pos += 1
-            if pos <= len
-                b = getbyte(buf, pos)
-                if UInt8('0') <= b <= UInt8('9')
-                    error = InvalidNumber
-                    @goto invalid
-                end
-            end
-        elseif UInt8('1') <= b <= UInt8('9')
-            while UInt8('0') <= b <= UInt8('9')
-                digit = Int64(b - UInt8('0'))
-                if val > INT64_OVERFLOW_VAL || (val == INT64_OVERFLOW_VAL && digit > INT64_OVERFLOW_DIGIT)
-                    overflow = true
-                    break
-                end
-                val = Int64(10) * val + digit
-                pos += 1
-                pos > len && break
-                b = getbyte(buf, pos)
-            end
-            if overflow
-                bval = BigInt(val)
-                while UInt8('0') <= b <= UInt8('9')
-                    digit = BigInt(b - UInt8('0'))
-                    bval = BigInt(10) * bval + digit
-                    pos += 1
-                    pos > len && break
-                    b = getbyte(buf, pos)
-                end
-            end
-        else
-            error = InvalidNumber
-            @goto invalid
-        end
-        # Check for decimal or exponent
-        if b == UInt8('.') || b == UInt8('e') || b == UInt8('E')
-            isfloat = true
-            # in strict JSON spec, we need at least one digit after the decimal
-            if b == UInt8('.')
-                pos += 1
-                if pos > len
-                    error = UnexpectedEOF
-                    @goto invalid
-                end
-                b = getbyte(buf, pos)
-                if !(UInt8('0') <= b <= UInt8('9'))
-                    error = InvalidNumber
-                    @goto invalid
-                end
+            if !(UInt8('0') <= b <= UInt8('9'))
+                error = InvalidNumber
+                @goto invalid
             end
         end
     end
-    if isfloat || opts.allownan
-        if opts.allownan
-            # check for NaN, Inf, -Inf
-            @check_special(opts.nan, NaN)
-            @check_special(opts.inf, Inf)
-            @check_special(opts.ninf, -Inf)
-        end
+
+    if isfloat
         res = Parsers.xparse2(Float64, buf, startpos, len)
         if !opts.allownan && Parsers.specialvalue(res.code)
             # if we overflowed, then let's try BigFloat

--- a/src/lazy.jl
+++ b/src/lazy.jl
@@ -587,7 +587,6 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
     b = getbyte(buf, pos)
     startpos = pos
     isneg = isfloat = overflow = false
-
     if opts.allownan
         # If this doesn't start like an integer, let Parsers handle
         # NaN/Inf/-Inf and the configured special values.
@@ -602,12 +601,10 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
             isfloat = !(UInt8('0') <= b <= UInt8('9'))
         end
     end
-
     if !isfloat
         val = Int64(0)
         b = getbyte(buf, pos)
         isneg = b == UInt8('-')
-
         if isneg || b == UInt8('+') # spec doesn't allow leading +, but we do
             pos += 1
             if pos > len
@@ -616,7 +613,6 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
             end
             b = getbyte(buf, pos)
         end
-
         # Parse integer part, check for leading zeros (invalid JSON)
         if b == UInt8('0')
             pos += 1
@@ -630,8 +626,7 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
         elseif UInt8('1') <= b <= UInt8('9')
             while UInt8('0') <= b <= UInt8('9')
                 digit = Int64(b - UInt8('0'))
-                if val > INT64_OVERFLOW_VAL ||
-                   (val == INT64_OVERFLOW_VAL && digit > INT64_OVERFLOW_DIGIT)
+                if val > INT64_OVERFLOW_VAL || (val == INT64_OVERFLOW_VAL && digit > INT64_OVERFLOW_DIGIT)
                     overflow = true
                     break
                 end
@@ -640,7 +635,6 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
                 pos > len && break
                 b = getbyte(buf, pos)
             end
-
             if overflow
                 bval = BigInt(val)
                 while UInt8('0') <= b <= UInt8('9')
@@ -655,11 +649,9 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
             error = InvalidNumber
             @goto invalid
         end
-
         # Check for decimal or exponent
         if b == UInt8('.') || b == UInt8('e') || b == UInt8('E')
             isfloat = true
-
             # in strict JSON spec, we need at least one digit after the decimal
             if b == UInt8('.')
                 pos += 1
@@ -683,9 +675,7 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
             @check_special(opts.inf, Inf)
             @check_special(opts.ninf, -Inf)
         end
-
         res = Parsers.xparse2(Float64, buf, startpos, len)
-
         if !opts.allownan && Parsers.specialvalue(res.code)
             # if we overflowed, then let's try BigFloat
             bres = Parsers.xparse2(BigFloat, buf, startpos, len)
@@ -693,12 +683,10 @@ isbigfloat(x::NumberResult) = x.tag == BIGFLOAT
                 return NumberResult(bres.val), startpos + Int(bres.tlen)
             end
         end
-
         if Parsers.invalid(res.code)
             error = InvalidNumber
             @goto invalid
         end
-
         return NumberResult(res.val), Int(startpos + res.tlen)
     else
         if overflow

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -407,6 +407,9 @@ JSON.lift(::DateMaterializedObjectStyle, ::Type{Date}, x::JSON.Object) = Date(x[
     # allownan for parsing normally invalid json values
     @test JSON.parse("NaN"; allownan=true) === NaN
     @test JSON.parse("Inf"; inf="Inf", allownan=true) === Inf
+    # allownan with typemax Int
+    @test JSON.parse(string(typemax(Int64)), Int64; allownan=true) === typemax(Int64) 
+    @test JSON.parse(string(typemax(Int128)), Int128; allownan=true) === typemax(Int128) 
     # jsonlines support
     @test JSON.parse("1"; jsonlines=true) == [1]
     @test JSON.parse("1 \t"; jsonlines=true) == [1]

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -427,6 +427,9 @@ JSON.lift(::DateMaterializedObjectStyle, ::Type{Date}, x::JSON.Object) = Date(x[
     @test JSON.parse(string(2^53 + 1); allownan=true) === Int64(2^53 + 1)
     #allownan with typemax in struct
     @test JSON.parse("{\"a\":$(typemax(Int64))}", TestAllownanInt; allownan=true).a === typemax(Int64)
+    #Test that parsing "-" and "+" with allownan=true throws an error
+    @test_throws ArgumentError JSON.parse("-"; allownan=true)
+    @test_throws ArgumentError JSON.parse("+"; allownan=true)
     # jsonlines support
     @test JSON.parse("1"; jsonlines=true) == [1]
     @test JSON.parse("1 \t"; jsonlines=true) == [1]

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -187,6 +187,11 @@ end
     foo::String = "bar"
 end
 
+#struct for parsing typemax Int test
+struct TestAllownanInt
+    a::Int64
+end
+
 # example from JSON.parse docstring
 abstract type AbstractMonster end
 
@@ -406,10 +411,22 @@ JSON.lift(::DateMaterializedObjectStyle, ::Type{Date}, x::JSON.Object) = Date(x[
     @test_throws ArgumentError JSON.parse("trub")
     # allownan for parsing normally invalid json values
     @test JSON.parse("NaN"; allownan=true) === NaN
-    @test JSON.parse("Inf"; inf="Inf", allownan=true) === Inf
+    @test JSON.parse("Infinity"; allownan=true) === Inf
+    @test JSON.parse("-Infinity"; allownan=true) === -Inf
+    @test JSON.parse("Inf"; allownan=true) === Inf
+    @test JSON.parse("-Inf"; allownan=true) === -Inf
+    # Nested version
+    @test isequal(JSON.parse("[Inf,NaN,-Infinity]"; allownan=true), [Inf, NaN, -Inf])
     # allownan with typemax Int
-    @test JSON.parse(string(typemax(Int64)), Int64; allownan=true) === typemax(Int64) 
-    @test JSON.parse(string(typemax(Int128)), Int128; allownan=true) === typemax(Int128) 
+    @test JSON.parse(string(typemax(Int)), Int; allownan=true) === typemax(Int) 
+    @test JSON.parse(string(typemax(UInt64)), UInt64; allownan=true) === typemax(UInt64) 
+    @test JSON.parse(string(typemax(Int64)), Int64; allownan=true) === typemax(Int64)
+    @test JSON.parse(string(typemin(Int64)), Int64; allownan=true) === typemin(Int64) 
+    @test JSON.parse(string(typemax(Int64)); allownan=true) === typemax(Int64) 
+    @test JSON.parse(string(typemax(Int128)), Int128; allownan=true) === typemax(Int128)
+    @test JSON.parse(string(2^53 + 1); allownan=true) === Int64(2^53 + 1)
+    #allownan with typemax in struct
+    @test JSON.parse("{\"a\":$(typemax(Int64))}", TestAllownanInt; allownan=true).a === typemax(Int64)
     # jsonlines support
     @test JSON.parse("1"; jsonlines=true) == [1]
     @test JSON.parse("1 \t"; jsonlines=true) == [1]


### PR DESCRIPTION
## Summary
- correct parsenumber function and check_special macro to fix the bug
- add 2 tests (for Int64 and Int128) to ensure future versions will work with this

## Root Cause
When using allownan, any number was parse as Float, and then convert as Int if needed. But the parsing as Float64 was rounded from 2e63 -1 to 2e63. 

Notice: it's my first PR, so I may have done some mistakes. I ran all tests locally, and it was working. 

Fixes #478 